### PR TITLE
Fix syntax errors in roles-creation rule

### DIFF
--- a/rules/roles-creation.md
+++ b/rules/roles-creation.md
@@ -9,15 +9,6 @@ This rule adds a Roles field to the user based on some pattern
 
 ```js
 function (user, context, callback) {
-
-  addRolesToUser(user, function(err, roles) {
-    if (err) {
-      callback(error);
-    } else {
-      user.persistent.roles = roles;
-      callback(null, user, context);
-  });
-  
   // You can add a Role based on what you want
   // In this case I check domain
   var addRolesToUser = function(user, cb) {
@@ -25,6 +16,16 @@ function (user, context, callback) {
       cb(null, ['admin']);
     } else {
       cb(null, ['user']);
-  }
+    }
+  };
+    
+  addRolesToUser(user, function(err, roles) {
+    if (err) {
+      callback(err);
+    } else {
+      user.persistent.roles = roles;
+      callback(null, user, context);
+    }
+  });
 }
 ```


### PR DESCRIPTION
The current rule does not even compile, this fixes it.
