### PR TITLE
Fix mixpanel js syntax. Should close auth0/manage#92

### DIFF
--- a/rules/mixpanel-track-event.md
+++ b/rules/mixpanel-track-event.md
@@ -15,7 +15,7 @@ function (user, context, callback) {
     "event": "Sign In",
     "properties": {
         "distinct_id": user.user_id,
-        "token": YOUR_MIXPANEL_TOKEN,
+        "token": "{REPLACE_WITH_YOUR_MIXPANEL_TOKEN}",
         "application": context.clientName
     }
   };
@@ -23,7 +23,7 @@ function (user, context, callback) {
   var base64Event = new Buffer(JSON.stringify(mpEvent)).toString('base64');
 
   request.get({
-    url: 'http://api.mixpanel.com/track/}'
+    url: 'http://api.mixpanel.com/track/}',
     qs: {
       data: base64Event
     }


### PR DESCRIPTION
This should close auth0/manage#92 when updated and merged dependency.
### Before

![image](https://cloud.githubusercontent.com/assets/367429/5445903/e85b2090-8496-11e4-963d-286151f341c2.png)
### Now

![image](https://cloud.githubusercontent.com/assets/367429/5445906/fd14c356-8496-11e4-8b1b-4c52a3fc551e.png)
