### PR TITLE
remove error where TARGET_CLIENT_SECRET is undefined

### DIFF
--- a/rules/jwt.md
+++ b/rules/jwt.md
@@ -23,7 +23,7 @@ function (user, context, callback) {
   };
 
   user.id_token = jwt.sign(api_user, 
-  						   new Buffer(TARGET_CLIENT_SECRET, 'base64'),
+  						   new Buffer(CLIENT_SECRET, 'base64'),
   						   options);
   callback(null, user, context);
 }


### PR DESCRIPTION
The buffer() was using variable TARGET_CLIENT_SECRET but this variable is really declared as CLIENT_SECRET.  Make a straight copy/paste fail.  Not a big deal though.

Thanks