### PR TITLE
Abort tracking login/signup on delegation

### DIFF
--- a/rules/send-events-segmentio.md
+++ b/rules/send-events-segmentio.md
@@ -14,6 +14,12 @@ The `sendEvent` function is a simple wrapper around the [segment.io Track REST A
 
 ```js
 function(user, context, callback) {
+
+  // abort if user is calling the delegation endpoint
+  if(context.protocol === 'delegation'){
+      return callback(null, user, context);
+  }
+
   user.app_metadata = user.app_metadata || {};
   if(user.app_metadata.signedUp){
     sendEvent('login');


### PR DESCRIPTION
i am using Auth0 with an app based on Firebase. So after logging in I call the delegation endpoint to get a Firebase Token for authenticating with Firebase. This would trigger two events being sent to Segment.