### PR TITLE
Change sendgrid request to match the new API

### DIFF
--- a/rules/sendgrid.md
+++ b/rules/sendgrid.md
@@ -20,9 +20,10 @@ function(user, context, callback) {
 
   request.post( {
     url: 'https://api.sendgrid.com/api/mail.send.json',
+    headers: {
+      'Authorization': ‘Bearer ...'
+    },
     form: {
-      'api_user': 'YOUR SENDGRID API USER',
-      'api_key': 'YOUR SENDGRID API PASS',
       'to': 'admin@myapp.com',
       'subject': 'NEW SIGNUP',
       'from': 'admin@myapp.com',


### PR DESCRIPTION
The Zendgrid API v3 change the way we need to send api keys

https://sendgrid.com/docs/Classroom/Send/api_keys.html