### PR TITLE
Improve rule for creating leads

### DIFF
--- a/rules/creates-lead-salesforce.md
+++ b/rules/creates-lead-salesforce.md
@@ -10,38 +10,51 @@ This rule will check if this is the first user login, and in that case will call
 > Note: this sample implements very basic error handling.
 
 ```
-function (user, context, callback) {
+function (user, context, done) {
   user.app_metadata = user.app_metadata || {};
-  if (user.app_metadata.recordedAsLead){
-    return callback(null,user,callback);
+  if (user.app_metadata.recordedAsLead) {
+    return done(null,user,context);
   }
 
   //Populate the variables below with appropriate values
-  var SFCOM_CLIENT_ID = "...";
-  var SFCOM_CLIENT_SECRET = "...";
-  var USERNAME = "...";
-  var PASSWORD = "...";
+  var SFCOM_CLIENT_ID = configuration.SALESFORCE_CLIENT_ID;
+  var SFCOM_CLIENT_SECRET = configuration.SALESFORCE_CLIENT_SECRET;
+  var USERNAME = configuration.SALESFORCE_USERNAME;
+  var PASSWORD = configuration.SALESFORCE_PASSWORD;
 
   getAccessToken(SFCOM_CLIENT_ID, SFCOM_CLIENT_SECRET, USERNAME, PASSWORD,
     function(e,r) {
-      if (e) return callback(e);
-      
-      createLead( r.instance_url, r.access_token, function (e, result) {
-        if (e) return callback(e);
+      if (e) {
+        return console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user (getting access token): ' + user.user_id, e);
+      }
+
+      if (!r.instance_url) {
+        return console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user (getting access token - instance_url is undefined): ' + user.user_id);
+      }
+
+      if (!r.access_token) {
+        return console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user ((getting access token - access_token is undefined)): ' + user.user_id, e);
+      }
+
+      createLead(r.instance_url, r.access_token, function (e, result) {
+        if (e) {
+          return console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user (creating lead): ' + user.user_id, e);
+        }
+
+        if (!result.id) {
+          return console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user (creating lead): ' + user.user_id, result);
+        }
 
         user.app_metadata.recordedAsLead = true;
         auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
-          .then(function(){
-            callback(null, user, context);
-          })
-          .catch(function(err){
-            callback(err);
-          });
+          .then(function() {}, function(err) {
+            console.log('[SALESFORCE-ERROR] There was an error creating salesforce lead for user (updating metadata): ' + user.user_id, e);
+          }).done();
       });
     });
 
   //See http://www.salesforce.com/us/developer/docs/api/Content/sforce_api_objects_lead.htm
-  function createLead(url,access_token, callback){
+  function createLead(url, access_token, callback){
 
     //Can use many more fields
     var data = {
@@ -50,14 +63,15 @@ function (user, context, callback) {
     };
 
     request.post({
-      url: url + "/services/data/v20.0/sobjects/Lead/",
+      url: url + "/services/data/v20.0/sobjects/Lead",
       headers: {
-        "Authorization": "OAuth " + access_token,
-        "Content-type": "application/json"
+        "Authorization": "OAuth " + access_token
       },
-      body: JSON.stringify(data)
+      json: data
       }, function(e,r,b) {
-        if (e) return callback(e);
+        if (e) {
+          return callback(e);
+        }
         return callback(null,b);
       });
   }
@@ -73,9 +87,19 @@ function (user, context, callback) {
         username: username,
         password: password
       }}, function(e,r,b) {
-        if (e) return callback(e);
-        return callback(null,JSON.parse(b));
+        if (e) { return callback(e); }
+        var resJSON;
+        try {
+          resJSON = JSON.parse(b);
+        } catch (error) {
+          return callback(error);
+        }
+
+        return callback(null, resJSON);
       });
   }
+
+  done(null, user, context);
 }
+
 ```


### PR DESCRIPTION
The first callback don't send the context  as a parameter. This can break rules workflow.

Also the rule was refactored to the following: 
  * Make a fast call to the rule's callback so it won't  block waiting salesforce's to respond
  * Added a few error checks to match Salesforce's API
  * Moved API Keys and sensible data to configuration variables