### PR TITLE
Fixed rule: replaced semicolons for equals

### DIFF
--- a/rules/saml-configuration.md
+++ b/rules/saml-configuration.md
@@ -20,13 +20,13 @@ function (user, context, callback) {
   //context.samlConfiguration.destination: "http://foo";
   //context.samlConfiguration.lifetimeInSeconds: 3600;
   //context.samlConfiguration.mappings: {
-  //   "user_id":     "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
-  //   "email":       "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-  //   "name":        "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
-  //   "given_name":  "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
-  //   "family_name": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
-  //   "upn":         "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn",
-  //   "groups":      "http://schemas.xmlsoap.org/claims/Group"
+  //   "user_id" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+  //   "email" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+  //   "name" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+  //   "given_name" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+  //   "family_name" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+  //   "upn" = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn",
+  //   "groups" = "http://schemas.xmlsoap.org/claims/Group"
   // },
   //context.samlConfiguration.nameIdentifierFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
   //context.samlConfiguration.nameIdentifierProbes: [


### PR DESCRIPTION
Fixed a mistake in the assignation of variables in the property `mappings`.