### PR TITLE
handle timing bug, consistent base user_id behaivor

### DIFF
--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -10,56 +10,125 @@ This rule will link any accounts that have the same email address.
 > Note: When linking accounts, only the metadata of the target user is saved. If you want to merge the metadata of the two accounts you must do that manually. See the document on [Linking Accounts](https://auth0.com/docs/link-accounts) for more details.
 
 ```js
-function (user, context, callback) {
-  var request = require('request@2.56.0');
-  // Check if email is verified, we shouldn't automatically
-  // merge accounts if this is not the case.
-  if (!user.email_verified) {
+/**
+ * This Auth0 rule will link 2 accounts with the same email address. It will use the oldest account as the primary
+ * so that a oAuth user_id in Auth0 does not change from out beneath you
+ *
+ * @param user
+ * @param context
+ * @param callback
+ * @returns {*}
+ */
+function(user, context, callback) {
+  console.log('entering link accts rule with user', user);
+  console.log('context', context);
+
+  if (!user.email_verified) { //dont merge un-verified
+    console.error('* email NOT verified, returning');
     return callback(null, user, context);
   }
 
-  request({
-   url: auth0.baseUrl + '/users',
-   headers: {
-     Authorization: 'Bearer ' + auth0.accessToken
-   },
-   qs: {
-     search_engine: 'v2',
-     q: 'email:"' + user.email + '" -user_id:"' + user.user_id + '"',
-   }
-  },
-  function(err, response, body) {
-    if (err) return callback(err);
-    if (response.statusCode !== 200) return callback(new Error(body));
+  var currUserTmp     = user.user_id.split('|'),
+      currUserProvier = currUserTmp[0],
+      currUserId      = currUserTmp[1];
 
-    var data = JSON.parse(body);
-    if (data.length > 0) {
-      async.each(data, function(targetUser, cb) {
-        if (targetUser.email_verified) {
-          var aryTmp = targetUser.user_id.split('|');
-          var provider = aryTmp[0];
-          var targetUserId = aryTmp[1];
+  var userApiUrl   = auth0.baseUrl + '/users',
+      bearerHeader = 'Bearer ' + auth0.accessToken;
+
+  request({
+      url:     userApiUrl,
+      headers: {
+        Authorization: bearerHeader
+      },
+      qs:      {
+        search_engine: 'v2',
+        q:             'email:"' + user.email + '"',
+      }
+    },
+    function(err, response, body) {
+      if (err) {
+        return callback(err);
+      }
+
+      console.log('search result', body);
+      if (response.statusCode !== 200) {
+        return callback(new Error(body));
+      }
+
+      try {
+        var data = JSON.parse(body);
+        if (data.length <= 0) {
+          console.log('* No other users with same email address. returning');
+          return callback(null, user, context);
+        }
+
+        //There is a timing issue/bug where user that initated this rule, is not yet returning from the search results
+        var currUserInSearchResult = data.some(function(u) {
+          return u.identities.some(function(ident) {
+            return (ident.provider === currUserProvier && ident.user_id === currUserId);
+          });
+        });
+        if (!currUserInSearchResult) {
+          console.log('* current user NOT in search result. Manually adding', user.user_id);
+          data.push({
+            email_verified: true,
+            user_id:        user.user_id,
+            created_at:     user.created_at
+          });
+        }
+
+        data.sort(function(a, b) {
+          if (b.created_at > a.created_at) {
+            return -1;
+          } else if (b.created_at < a.created_at) {
+            return 1;
+          } else {
+            return 0;
+          }
+        });
+
+        var primaryUser = data.shift();
+        console.log('primary user', primaryUser);
+
+        if (data.length <= 0) {
+          console.log('* No other users with same email address.');
+          return callback(null, user, context);
+        }
+
+        async.each(data, function(targetUser, cb) {
+          if (!targetUser.email_verified) {
+            console.log('* targetUser', targetUser, 'does not have verified email. Skipping');
+            return cb();
+          }
+
+          var aryTmp       = targetUser.user_id.split('|'),
+              provider     = aryTmp[0],
+              targetUserId = aryTmp[1];
+
+          console.log('* linking', targetUser.user_id);
           request.post({
-            url: userApiUrl + '/' + user.user_id + '/identities',
+            url:     userApiUrl + '/' + primaryUser.user_id + '/identities',
             headers: {
-              Authorization: 'Bearer ' + auth0.accessToken
+              Authorization: bearerHeader
             },
-            json: { provider: provider, user_id: targetUserId }
+            json:    {provider: provider, user_id: targetUserId}
           }, function(err, response, body) {
-              if (response.statusCode >= 400) {
-               cb(new Error('Error linking account: ' + response.statusMessage));  
-              }
+            if (response.statusCode >= 400) {
+              cb(new Error('Error linking account: ' + response.statusMessage));
+            }
             cb(err);
           });
-        } else {
-          cb();
-        }
-      }, function(err) {
-        callback(err, user, context);
-      });
-    } else {
-      callback(null, user, context);
-    }
-  });
+
+        }, function(err) {
+          if (err) {
+            console.error('async err', err);
+          }
+          callback(err, user, context);
+        });
+      } catch (e) {
+        console.error('catch err', e);
+        callback(e);
+      }
+    });
 }
 ```


### PR DESCRIPTION
This update:
*  Uses the oldest account as the primary to provide consistency so that a oAuth user_id in Auth0 does not change from out beneath you.
*  Addresses a timing issue/bug where recently logged in user does not show up in user search results by email address.