### PR TITLE
Move callback() invocation into request.get()

### DIFF
--- a/rules/mixpanel-track-event.md
+++ b/rules/mixpanel-track-event.md
@@ -27,9 +27,9 @@ function (user, context, callback) {
     qs: {
       data: base64Event
     }
+  }, function (e, r, b){
+      // don’t wait for the MixPanel API call to finish, return right away (the request will continue on the sandbox)`
+      callback(null, user, context);
   });
 }
-
-// don’t wait for the MixPanel API call to finish, return right away (the request will continue on the sandbox)`
-callback(null,user,context);
 ```


### PR DESCRIPTION
I was working with the Tracks Logins in MixPanel rule
on the website and the callback() invocation was
throwing three errors (callback not defined,
user not defined, context not defined), and upon
invocation was failing with:
 ERROR: Invalid response code from the auth0-sandbox: HTTP 400.
 Unable to compile submitted JavaScript.
 SyntaxError: Unexpected identifier SyntaxError: Unexpected identifier
I modified the script as in this request and it worked.

This change, if valid, will probably need to be applied to
other places as well, like the website.

![image](https://cloud.githubusercontent.com/assets/11715799/14741003/d59a38f8-089b-11e6-8e32-abea172e59f8.png)
