### PR TITLE
Uncomment ignoreCookie

### DIFF
--- a/rules/duo-multifactor.md
+++ b/rules/duo-multifactor.md
@@ -28,7 +28,7 @@ function (user, context, callback) {
         host: 'api-3....049.duosecurity.com',
 
         // optional. Force DuoSecurity everytime this rule runs. Defaults to false. if accepted by users the cookie lasts for 30 days (this cannot be changed)
-        // ignoreCookie: true,
+        ignoreCookie: true,
 
         // optional. Use some attribute of the profile as the username in DuoSecurity. This is also useful if you already have your users enrolled in Duo.
         // username: user.nickname,

--- a/rules/google-multifactor.md
+++ b/rules/google-multifactor.md
@@ -26,7 +26,7 @@ function (user, context, callback) {
         provider: 'google-authenticator',
         // issuer: 'Label on Google Authenticator App', // optional
         // key: '{YOUR_KEY_HERE}', //  optional, the key to use for TOTP. by default one is generated for you
-        // ignoreCookie: true // optional, force Google Authenticator everytime this rule runs. Defaults to false. if accepted by users the cookie lasts for 30 days (this cannot be changed)
+        ignoreCookie: true // optional, force Google Authenticator everytime this rule runs. Defaults to false. if accepted by users the cookie lasts for 30 days (this cannot be changed)
       };
     // }
   }

--- a/rules/guardian-multifactor.md
+++ b/rules/guardian-multifactor.md
@@ -21,7 +21,7 @@ function (user, context, callback) {
       context.multifactor = {
         provider: 'guardian', //required
 
-        // ignoreCookie: true, // optional. Force Auth0 MFA everytime this rule runs. Defaults to false. if accepted by users the cookie lasts for 30 days (this cannot be changed)
+        ignoreCookie: true, // optional. Force Auth0 MFA everytime this rule runs. Defaults to false. if accepted by users the cookie lasts for 30 days (this cannot be changed)
       };
     // }
   //}


### PR DESCRIPTION
There is some discussion regarding if we must change
behavior on auth0-server, but this is a workaround
to, at least, make rule behavior secure by default.