### PR TITLE
fix missing userApiUrl error

### DIFF
--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -31,7 +31,7 @@ function (user, context, callback) {
   function(err, response, body) {
     if (err) return callback(err);
     if (response.statusCode !== 200) return callback(new Error(body));
-
+    var userApiUrl = "https://YOUR_DOMAIN_NAME.auth0.com/api/v2/users"; //provide your domain name
     var data = JSON.parse(body);
     if (data.length > 0) {
       async.each(data, function(targetUser, cb) {


### PR DESCRIPTION
the variable "userApiUrl" is undeclared. it must point to the api url like that:
var userApiUrl = "https://YOUR_DOMAIN_NAME.auth0.com/api/v2/users";

without this the rule does not work