### PR TITLE
Correct call to management user api

### DIFF
--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -40,7 +40,7 @@ function (user, context, callback) {
           var provider = aryTmp[0];
           var targetUserId = aryTmp[1];
           request.post({
-            url: userApiUrl + '/' + user.user_id + '/identities',
+            url: auth0.baseUrl + '/users/' + user.user_id + '/identities',
             headers: {
               Authorization: 'Bearer ' + auth0.accessToken
             },


### PR DESCRIPTION
Hi there,

There is a small typo in the rule for linking user accounts. The correct url endpoint can be retrieved from the auth0 object.

Cheers,
Robin