### PR TITLE
Add proper state parameter support to sms-mfa redirect rule

### DIFF
--- a/redirect-rules/sms-mfa/README.md
+++ b/redirect-rules/sms-mfa/README.md
@@ -1,31 +1,49 @@
-#Auth0 - SMS Passwordless MFA
+# Auth0 - SMS Passwordless MFA
 
 This rule and webtask will add [SMS Passwordless](https://auth0.com/passwordless) capabilities to your Auth0 account.
 
-##Setup
+## Setup
 
-1- Create the webtask
-    - Follow the instructions to install the `wt-cli` tool and setup it for your [Auth0 account](https://manage.auth0.com/#/account/webtasks) and copy the url generated (without any get param).
-    - Create your SMS MFA webtask: 
-```js
-    wt create --name passwordless-sms-mfa \
-        --secret client_secret=yourclientsecret \
-        --secret auth0_domain=yourdomain.auth0.com \
-        --output url mfa-passwordless.js --no-parse --no-merge
-```
-    Parameters:
-        - *client_secret*: The secret you want to use to sign the tokens used between the rule and the webtask.
-        - *auth0_domain*: Your auth0 subdomain: *domain*.auth0.com
-2- Create a new rule in your Auth0 account, copy the code from [rule.js](https://github.com/auth0/auth0-sms-passwordless/blob/master/rule.js) and replace the `client_id` of the application where you want to use the SMS MFAs.
->Go to the Rules section in the [Auth0 Dashboard](https://manage.auth0.com/#/rules). Click on *New Rule* and select *Empty rule*. Set the name of the rule and copy the code there.
+1. Create the webtask
+  - Follow the instructions to install the `wt-cli` tool and setup it for your [Auth0 account](https://manage.auth0.com/#/account/webtasks).
+  - Capture your webtask profile:
+  ```bash
+  WEBTASK_PROFILE=yourdomain-default
+  ```
+  Where `yourdomain-default` is the webtask profile associated with your Auth0 tenant, which you should have got from the previous step.
+  - Generate a secret that can be used to sign JWT tokens passed between the rule and the webtask:  
+  ```bash
+  TOKEN_SECRET=$(openssl rand 32 -base64)
+  ```
+  - Capture your Auth0 domain:
+  ```bash
+  AUTH0_DOMAIN=yourdomain.auth0.com
+  ```
+  Where `yourdomain.auth0.com` is your Auth0 tenant domain
+  - Create your SMS MFA webtask:  
+  ```bash
+  wt create webtask.js \
+    --name sms-mfa \
+    --secret token_secret=$TOKEN_SECRET \
+    --secret auth0_domain=$AUTH0_DOMAIN \
+    --no-parse --no-merge \
+    --profile $WEBTASK_PROFILE
+  ```
+  - Take note of the resulting webtask URL
+2. Create a new rule in your Auth0 account, copy the code from [rule.js](https://github.com/auth0/auth0-sms-passwordless/blob/master/rule.js) and replace the `client_id` of the application where you want to use the SMS MFAs.  
+  >Go to the Rules section in the [Auth0 Dashboard](https://manage.auth0.com/#/rules). Click on *New Rule* and select *Empty rule*. Set the name of the rule and copy the code there.
 
-3- Set up the rules parameters in the Rules Setting section (under the rules list):
-    - *sms_passwordless_mfa_url*: The url of the webtask.
-    - *sms_passwordless_mfa_secret*: The secret you want to use to sign the tokens used between the rule and the webtask (it should be the same configured in the webtask).
+3. Set up the rules parameters in the Rules Setting section (under the rules list):
+    - `SMS_MFA_URL`: The url of the webtask.
+    - `SMS_MFA_TOKEN_SECRET`: The `TOKEN_SECRET` generated in step 1, which you can copy into the clipboard with this command:  
+      ```bash
+      echo $TOKEN_SECRET | pbcopy
+      ```
 
-4- Set up your SMS Passwordless connection [Here](https://manage.auth0.com/#/connections/passwordless).
+4. Set up your SMS Passwordless connection [Here](https://manage.auth0.com/#/connections/passwordless).
 
-##How it works
+## How it works
+
 The rule will run on each user login and if the user has an SMS identity linked in his/her account, it will send an sms and ask for the code sent. If the code entered is the one sent, the login flow will continue.
 
 If the user does not have an SMS identity, the rule will be skipped.

--- a/redirect-rules/sms-mfa/mfa-passwordless.js
+++ b/redirect-rules/sms-mfa/mfa-passwordless.js
@@ -15,7 +15,6 @@ function hereDoc(f) {
 }
 
 app.get('/', function (req, res) {
-  var callback_url = 'https://webtask.it.auth0.com/api/run/' + req.x_wt.container + '/' + req.x_wt.jtn + 'widget-callback';
   var token = req.query.token;
   var state = req.query.state;
 
@@ -30,7 +29,7 @@ app.get('/', function (req, res) {
       res.end('error');
       return;
     } else {
-      sendCodeAndShowPasswordlessSecondStep(res, callback_url, req.webtaskContext, decoded, state);
+      sendCodeAndShowPasswordlessSecondStep(res, req.webtaskContext, decoded, state);
     }
   });
 });
@@ -62,7 +61,7 @@ app.post('/', function (req, res) {
   });
 });
 
-function redirectBack (res, webtaskContext, decoded, success, state) {
+function redirectBack(res, webtaskContext, decoded, success, state) {
   var token = jwt.sign({
       status: success ? 'ok' : 'fail'
     },
@@ -80,7 +79,7 @@ function redirectBack (res, webtaskContext, decoded, success, state) {
   res.end();
 }
 
-function sendCodeAndShowPasswordlessSecondStep (res, callback_url, webtaskContext, decoded_token, state) {
+function sendCodeAndShowPasswordlessSecondStep(res, webtaskContext, decoded_token, state) {
   request({
     method: 'POST',
     url: "https://" + webtaskContext.data.auth0_domain + "/passwordless/start",
@@ -90,14 +89,14 @@ function sendCodeAndShowPasswordlessSecondStep (res, callback_url, webtaskContex
       phone_number: decoded_token.sms_identity.profileData.phone_number
     }
   }).then(function(response){
-    showPasswordlessSecondStep(res, callback_url, webtaskContext, decoded_token, state);
+    showPasswordlessSecondStep(res, webtaskContext, decoded_token, state);
   }).catch(function(e){
     console.log('ERROR SENDING SMS', e);
      //A client error like 400 Bad Request happened
   });
 }
 
-function showPasswordlessSecondStep (res, callback_url, webtaskContext, decoded_token, state) {
+function showPasswordlessSecondStep(res, webtaskContext, decoded_token, state) {
   res.writeHead(200, {
     'Content-Type': 'text/html'
   });
@@ -109,7 +108,7 @@ function showPasswordlessSecondStep (res, callback_url, webtaskContext, decoded_
   }));
 }
 
-function passwordlessSecondStepForm () {
+function passwordlessSecondStepForm() {
 /*
 <!DOCTYPE html>
 <html lang="en">

--- a/redirect-rules/sms-mfa/mfa-passwordless.js
+++ b/redirect-rules/sms-mfa/mfa-passwordless.js
@@ -1,15 +1,12 @@
 var Express = require('express');
 var Webtask = require('webtask-tools');
 var jwt = require('jsonwebtoken');
+var bodyParser = require('body-parser');
+var Bluebird = require('bluebird');
+var request = Bluebird.promisify(require('request'));
 
 var app = Express();
-
-var bodyParser = require('body-parser');
-
 app.use(bodyParser.urlencoded({ extended: false }));
-
-var Promise = require("bluebird");
-var request = Promise.promisify(require("request"));
 
 function hereDoc(f) {
   return f.toString().
@@ -18,13 +15,10 @@ function hereDoc(f) {
 }
 
 app.get('/', function (req, res) {
-
-  var callback_url = "https://webtask.it.auth0.com/api/run/"+req.x_wt.container+"/"+req.x_wt.jtn+"/widget-callback";
-
+  var callback_url = 'https://webtask.it.auth0.com/api/run/' + req.x_wt.container + '/' + req.x_wt.jtn + 'widget-callback';
   var token = req.query.token;
 
   jwt.verify(token, new Buffer(req.webtaskContext.data.client_secret,'base64'), function(err, decoded) {
-
     if (err) {
       res.end('error');
       return;
@@ -35,18 +29,15 @@ app.get('/', function (req, res) {
       res.end('error');
       return;
     } else {
-
       sendCodeAndShowPasswordlessSecondStep(res, callback_url, req.webtaskContext, decoded);
     }
   });
-
 });
 
 app.post('/', function (req, res) {
   var token = req.body.token;
 
-  jwt.verify(token, new Buffer(req.webtaskContext.data.client_secret,'base64'), function(err, decoded) {
-
+  jwt.verify(token, new Buffer(req.webtaskContext.data.client_secret, 'base64'), function(err, decoded) {
     if (err) {
       res.end('error on callback token verification');
       return;
@@ -54,9 +45,9 @@ app.post('/', function (req, res) {
 
     request({
       method: 'POST',
-      url: "https://" + req.webtaskContext.data.auth0_domain + "/passwordless/verify",
+      url: 'https://' + req.webtaskContext.data.auth0_domain + '/passwordless/verify',
       json: {
-        connection: "sms",
+        connection: 'sms',
         phone_number: decoded.sms_identity.profileData.phone_number,
         verification_code: req.body.code
       }
@@ -66,7 +57,6 @@ app.post('/', function (req, res) {
       console.log('ERROR VERIFYING', e);
        //A client error like 400 Bad Request happened
     });
-
   });
 });
 
@@ -82,7 +72,9 @@ function redirectBack(res, webtaskContext, decoded, success) {
       issuer: 'urn:auth0:sms:mfa'
     });
 
-  res.writeHead(301, {Location: 'https://'+ webtaskContext.data.auth0_domain + "/continue" + "?id_token=" + token});
+  res.writeHead(301, {
+    Location: 'https://'+ webtaskContext.data.auth0_domain + '/continue' + '?id_token=' + token
+  });
   res.end();
 }
 
@@ -96,9 +88,7 @@ function sendCodeAndShowPasswordlessSecondStep(res, callback_url, webtaskContext
       phone_number: decoded_token.sms_identity.profileData.phone_number
     }
   }).then(function(response){
-
     showPasswordlessSecondStep(res, callback_url, webtaskContext, decoded_token);
-
   }).catch(function(e){
     console.log('ERROR SENDING SMS', e);
      //A client error like 400 Bad Request happened
@@ -117,7 +107,7 @@ function showPasswordlessSecondStep(res, callback_url, webtaskContext, decoded_t
   ));
 }
 
-function passwordlessSecondStepForm() {
+function passwordlessSecondStepForm () {
 /*
 <!DOCTYPE html>
 <html lang="en">

--- a/redirect-rules/sms-mfa/rule.js
+++ b/redirect-rules/sms-mfa/rule.js
@@ -1,4 +1,4 @@
-function (user, context, callback) {
+function performSmsMfa (user, context, callback) {
   var jwt = require('jsonwebtoken');
 
   //check SMS MFA is enabled for the client
@@ -6,42 +6,44 @@ function (user, context, callback) {
 
   // run only for the specified clients
   if (CLIENTS_WITH_MFA.indexOf(context.clientID) === -1) {
-    return callback(null,user,context);
+    return callback(null, user, context);
   }
 
   //Returning from MFA validation
   if(context.protocol === 'redirect-callback') {
-    var decoded = jwt.verify(context.request.query.id_token, new Buffer(configuration.sms_passwordless_mfa_secret,'base64'));
+    var decoded = jwt.verify(context.request.query.id_token, new Buffer(configuration.sms_passwordless_mfa_secret, 'base64'));
     if(!decoded) return callback(new Error('Invalid Token'));
     if(decoded.status !== 'ok') return callback(new Error('Invalid Token Status'));
 
-    return callback(null,user,context);
+    return callback(null, user, context);
   }
 
   //CHECK FOR SMS IDENTITY
-  var sms_connections = user.identities.filter(function(id){ return id.provider === 'sms' && id.profileData && id.profileData.phone_verified; });
+  var sms_connections = user.identities.filter(function (id) {
+    return id.provider === 'sms' && id.profileData && id.profileData.phone_verified;
+  });
   var token_payload = {};
 
   //IF NO SMS IDENTITY, SKIP
   if (sms_connections.length === 0) {
     return callback(null,user,context);
   }
-  
+
   token_payload.sms_identity = sms_connections[0];
 
-  var token = jwt.sign(token_payload, 
-      new Buffer(configuration.sms_passwordless_mfa_secret, 'base64'),
-      {
-        subject: user.user_id,
-        expiresInMinutes: 15,
-        audience: context.clientID,
-        issuer: 'urn:auth0:sms:mfa'
-      });
+  var token = jwt.sign(token_payload,
+    new Buffer(configuration.sms_passwordless_mfa_secret, 'base64'),
+    {
+      subject: user.user_id,
+      expiresInMinutes: 15,
+      audience: context.clientID,
+      issuer: 'urn:auth0:sms:mfa'
+    });
 
 
   //Trigger MFA
   context.redirect = {
-    url: configuration.sms_passwordless_mfa_url + "?token=" + token // check this
+    url: configuration.sms_passwordless_mfa_url + '?token=' + token // check this
   };
 
   callback(null,user,context);

--- a/redirect-rules/sms-mfa/rule.js
+++ b/redirect-rules/sms-mfa/rule.js
@@ -11,7 +11,7 @@ function performSmsMfa (user, context, callback) {
 
   //Returning from MFA validation
   if(context.protocol === 'redirect-callback') {
-    var decoded = jwt.verify(context.request.query.id_token, new Buffer(configuration.sms_passwordless_mfa_secret, 'base64'));
+    var decoded = jwt.verify(context.request.query.id_token, new Buffer(configuration.SMS_MFA_TOKEN_SECRET, 'base64'));
     if(!decoded) return callback(new Error('Invalid Token'));
     if(decoded.status !== 'ok') return callback(new Error('Invalid Token Status'));
 
@@ -32,7 +32,7 @@ function performSmsMfa (user, context, callback) {
   token_payload.sms_identity = sms_connections[0];
 
   var token = jwt.sign(token_payload,
-    new Buffer(configuration.sms_passwordless_mfa_secret, 'base64'),
+    new Buffer(configuration.SMS_MFA_TOKEN_SECRET, 'base64'),
     {
       subject: user.user_id,
       expiresInMinutes: 15,
@@ -43,7 +43,7 @@ function performSmsMfa (user, context, callback) {
 
   //Trigger MFA
   context.redirect = {
-    url: configuration.sms_passwordless_mfa_url + '?token=' + token // check this
+    url: configuration.SMS_MFA_URL + '?token=' + token // check this
   };
 
   callback(null,user,context);

--- a/redirect-rules/sms-mfa/webtask.js
+++ b/redirect-rules/sms-mfa/webtask.js
@@ -18,7 +18,7 @@ app.get('/', function (req, res) {
   var token = req.query.token;
   var state = req.query.state;
 
-  jwt.verify(token, new Buffer(req.webtaskContext.data.client_secret,'base64'), function(err, decoded) {
+  jwt.verify(token, new Buffer(req.webtaskContext.secrets.token_secret, 'base64'), function(err, decoded) {
     if (err) {
       res.end('error');
       return;
@@ -38,7 +38,7 @@ app.post('/', function (req, res) {
   var token = req.body.token;
   var state = req.body.state;
 
-  jwt.verify(token, new Buffer(req.webtaskContext.data.client_secret, 'base64'), function(err, decoded) {
+  jwt.verify(token, new Buffer(req.webtaskContext.secrets.token_secret, 'base64'), function(err, decoded) {
     if (err) {
       res.end('error on callback token verification');
       return;
@@ -46,7 +46,7 @@ app.post('/', function (req, res) {
 
     request({
       method: 'POST',
-      url: 'https://' + req.webtaskContext.data.auth0_domain + '/passwordless/verify',
+      url: 'https://' + req.webtaskContext.secrets.auth0_domain + '/passwordless/verify',
       json: {
         connection: 'sms',
         phone_number: decoded.sms_identity.profileData.phone_number,
@@ -65,7 +65,7 @@ function redirectBack(res, webtaskContext, decoded, success, state) {
   var token = jwt.sign({
       status: success ? 'ok' : 'fail'
     },
-    new Buffer(webtaskContext.data.client_secret, 'base64'),
+    new Buffer(webtaskContext.secrets.token_secret, 'base64'),
     {
       subject: decoded.sub,
       expiresInMinutes: 1,
@@ -74,7 +74,7 @@ function redirectBack(res, webtaskContext, decoded, success, state) {
     });
 
   res.writeHead(301, {
-    Location: 'https://'+ webtaskContext.data.auth0_domain + '/continue' + '?id_token=' + token + '&state=' + state
+    Location: 'https://'+ webtaskContext.secrets.auth0_domain + '/continue' + '?id_token=' + token + '&state=' + state
   });
   res.end();
 }
@@ -82,7 +82,7 @@ function redirectBack(res, webtaskContext, decoded, success, state) {
 function sendCodeAndShowPasswordlessSecondStep(res, webtaskContext, decoded_token, state) {
   request({
     method: 'POST',
-    url: "https://" + webtaskContext.data.auth0_domain + "/passwordless/start",
+    url: "https://" + webtaskContext.secrets.auth0_domain + "/passwordless/start",
     json: {
       client_id: decoded_token.aud,
       connection: "sms",


### PR DESCRIPTION
Currently the [sms-mfa](https://github.com/auth0/rules/tree/master/redirect-rules/sms-mfa) redirect rule sample is broken for tenants that have the *OAuth2 as a Service* flag enabled, because in that mode Auth0 requires that the `state` query parameter that was passed to the redirect endpoint be passed back to Auth0 when the `/continue` endpoint is called.

This PR fixes that issue and does a little extra clean-up.