### PR TITLE
Check for property before using indexOf

### DIFF
--- a/rules/roles-creation.md
+++ b/rules/roles-creation.md
@@ -14,7 +14,7 @@ function (user, context, callback) {
   // You can add a Role based on what you want
   // In this case I check domain
   var addRolesToUser = function(user, cb) {
-    if (user.email.indexOf('@example.com') > -1) {
+    if (user.email && user.email.indexOf('@example.com') > -1) {
       cb(null, ['admin']);
     } else {
       cb(null, ['user']);


### PR DESCRIPTION
Check for `user.email` to be defined before using `user.email.indexOf()`. This accounts for connections that don't provide email and sets an example for doing property checks in general when customizing this rule template.