### PR TITLE
Case insensitive email search bug fix proposal

### DIFF
--- a/rules/link-users-by-email-with-metadata.md
+++ b/rules/link-users-by-email-with-metadata.md
@@ -27,7 +27,7 @@ function (user, context, callback) {
    },
    qs: {
      search_engine: 'v2',
-     q: 'email.raw:"' + user.email + '" -user_id:"' + user.user_id + '"',
+     q: 'email:"' + user.email + '" -user_id:"' + user.user_id + '"',
    }
   },
   function(err, response, body) {

--- a/rules/link-users-by-email-with-metadata.md
+++ b/rules/link-users-by-email-with-metadata.md
@@ -37,7 +37,7 @@ function (user, context, callback) {
     var data = JSON.parse(body);
     if (data.length > 0) {
       async.each(data, function(targetUser, cb) {
-        if (targetUser.email_verified) {
+        if (targetUser.email_verified && targetUser.email.toLowerCase() === user.email.toLowerCase()) {
           var aryTmp = targetUser.user_id.split('|');
           var provider = aryTmp[0];
           var targetUserId = aryTmp[1];


### PR DESCRIPTION
Without this change the rule is case sensitive and the emails are not being linked.

The rule as it is will be case sensitive and linking of accounts with emails like `Risco2008@live.com` (from google or live account) will not be linked with DB-Connections users `risco2008@live.com`.

Unless the field `email.raw` is used for specific purposes which I am unaware of I suggest using the `email` instead of `email.raw`.