### PR TITLE
Corrected missing semicolon on HEC track event.

### DIFF
--- a/rules/splunk-HEC-track-event.md
+++ b/rules/splunk-HEC-track-event.md
@@ -45,7 +45,7 @@ function(user, context, callback) {
     headers: {
         'Authorization': 'Splunk ' + token
       },
-    strictSSL: true // set to false if using a self-signed cert
+    strictSSL: true, // set to false if using a self-signed cert
     json: hec_event
   }, function(e,r,b) {
     if (e) return callback(e);


### PR DESCRIPTION
Hi,

Just a quick fix for something I encountered using the HEC rule.

Prior to this fix, a new `Tracks Logins/SignUps With Splunk HEC` rule will not compile.

![Issue Details](https://user-images.githubusercontent.com/637298/29244987-7817c4f8-800d-11e7-8e76-c93ee6bd3666.png)
