### PR TITLE
Fix primaryUser issue

### DIFF
--- a/rules/link-users-by-email-with-metadata.md
+++ b/rules/link-users-by-email-with-metadata.md
@@ -44,17 +44,18 @@ function (user, context, callback) {
     }
     
     var originalUser = data[0];
-    var aryTmp = user.user_id.split('|');
-    var provider = aryTmp[0];
-    var newUserId = aryTmp[1];
+    var user_id = user.user_id;
+    var pipePos = user_id.indexOf('|');
+    var provider = user_id.slice(0, pipePos);
+    var newUserId = user_id.slice(pipePos + 1);
 
     user.app_metadata = user.app_metadata || {};
     user.user_metadata = user.user_metadata || {};
-    auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
-    .then(auth0.users.updateUserMetadata(user.user_id, user.user_metadata))
+    auth0.users.updateAppMetadata(originalUser.user_id, user.app_metadata)
+    .then(auth0.users.updateUserMetadata(originalUser.user_id, user.user_metadata))
     .then(function(){
       request.post({
-        url: userApiUrl + '/' + user.user_id + '/identities',
+        url: userApiUrl + '/' + originalUser.user_id + '/identities',
         headers: {
           Authorization: 'Bearer ' + auth0.accessToken
         },

--- a/rules/link-users-by-email-with-metadata.md
+++ b/rules/link-users-by-email-with-metadata.md
@@ -27,7 +27,7 @@ function (user, context, callback) {
    },
    qs: {
      search_engine: 'v2',
-     q: 'email:"' + user.email + '" -user_id:"' + user.user_id + '"',
+     q: 'email.raw:"' + user.email + '" AND email_verified: "true" -user_id:"' + user.user_id + '"',
    }
   },
   function(err, response, body) {
@@ -35,43 +35,41 @@ function (user, context, callback) {
     if (response.statusCode !== 200) return callback(new Error(body));
 
     var data = JSON.parse(body);
-    if (data.length > 0) {
-      async.each(data, function(targetUser, cb) {
-        if (targetUser.email_verified && targetUser.email.toLowerCase() === user.email.toLowerCase()) {
-          var aryTmp = targetUser.user_id.split('|');
-          var provider = aryTmp[0];
-          var targetUserId = aryTmp[1];
-
-          targetUser.app_metadata = targetUser.app_metadata || {};
-          targetUser.user_metadata = targetUser.user_metadata || {};
-          auth0.users.updateAppMetadata(user.user_id, targetUser.app_metadata)
-          .then(auth0.users.updateUserMetadata(user.user_id, targetUser.user_metadata))
-          .then(function(){
-            request.post({
-              url: userApiUrl + '/' + user.user_id + '/identities',
-              headers: {
-                Authorization: 'Bearer ' + auth0.accessToken
-              },
-              json: { provider: provider, user_id: targetUserId }
-            }, function(err, response, body) {
-                if (response && response.statusCode >= 400) {
-                  return cb(new Error('Error linking account: ' + response.statusMessage));
-                }
-                cb(err);
-            });
-          })
-          .catch(function(err){
-            cb(err);
-          });
-        } else {
-          cb();
-        }
-      }, function(err) {
-        callback(err, user, context);
-      });
-    } else {
-      callback(null, user, context);
+    if (data.length > 1) {
+      return callback(new Error('[!] Rule: Multiple user profiles already exist - cannot select base profile to link with'));
     }
+    if (data.length === 0) {
+      console.log('[-] Skipping link rule');
+      return callback(null, user, context);
+    }
+    
+    var originalUser = data[0];
+    var aryTmp = user.user_id.split('|');
+    var provider = aryTmp[0];
+    var newUserId = aryTmp[1];
+
+    user.app_metadata = user.app_metadata || {};
+    user.user_metadata = user.user_metadata || {};
+    auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+    .then(auth0.users.updateUserMetadata(user.user_id, user.user_metadata))
+    .then(function(){
+      request.post({
+        url: userApiUrl + '/' + user.user_id + '/identities',
+        headers: {
+          Authorization: 'Bearer ' + auth0.accessToken
+        },
+        json: { provider: provider, user_id: newUserId }
+      }, function(err, response, body) {
+          if (response && response.statusCode >= 400) {
+            return cb(new Error('Error linking account: ' + response.statusMessage));
+          }
+          context.primaryUser = originalUser.user_id;
+          callback(null, user, context);
+      });
+    })
+    .catch(function(err){
+      cb(err);
+    });
   });
 }
 ```

--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -11,7 +11,7 @@ This rule will link any accounts that have the same email address.
 > Note: When linking accounts, only the metadata of the target user is saved. If you want to merge the metadata of the two accounts you must do that manually. See the document on [Linking Accounts](https://auth0.com/docs/link-accounts) for more details.
 
 ```js
-function (user, context, callback) {
+function(user, context, callback) {
   var request = require('request@2.56.0');
   // Check if email is verified, we shouldn't automatically
   // merge accounts if this is not the case.
@@ -21,47 +21,48 @@ function (user, context, callback) {
   var userApiUrl = auth0.baseUrl + '/users';
 
   request({
-   url: userApiUrl,
-   headers: {
-     Authorization: 'Bearer ' + auth0.accessToken
-   },
-   qs: {
-     search_engine: 'v2',
-     q: 'email:"' + user.email + '" -user_id:"' + user.user_id + '"',
-   }
-  },
-  function(err, response, body) {
-    if (err) return callback(err);
-    if (response.statusCode !== 200) return callback(new Error(body));
+      url: userApiUrl,
+      headers: {
+        Authorization: 'Bearer ' + auth0.accessToken
+      },
+      qs: {
+        search_engine: 'v2',
+        q: 'email.raw:"' + user.email + '" AND email_verified: "true" -user_id:"' + user.user_id + '"',
+      }
+    },
+    function(err, response, body) {
+      if (err) return callback(err);
+      if (response.statusCode !== 200) return callback(new Error(body));
 
-    var data = JSON.parse(body);
-    if (data.length > 0) {
-      async.each(data, function(targetUser, cb) {
-        if (targetUser.email_verified && targetUser.email.toLowerCase() === user.email.toLowerCase()) {
-          var aryTmp = targetUser.user_id.split('|');
-          var provider = aryTmp[0];
-          var targetUserId = aryTmp[1];
-          request.post({
-            url: userApiUrl + '/' + user.user_id + '/identities',
-            headers: {
-              Authorization: 'Bearer ' + auth0.accessToken
-            },
-            json: { provider: provider, user_id: targetUserId }
-          }, function(err, response, body) {
-              if (response && response.statusCode >= 400) {
-               return cb(new Error('Error linking account: ' + response.statusMessage));
-              }
-            cb(err);
-          });
-        } else {
-          cb();
+      var data = JSON.parse(body);
+      if (data.length > 1) {
+        return callback(new Error('[!] Rule: Multiple user profiles already exist - cannot select base profile to link with'));
+      }
+      if (data.length === 0) {
+        console.log('[-] Skipping link rule');
+        return callback(null, user, context);
+      }
+
+      var originalUser = data[0];
+      var aryTmp = user.user_id.split('|');
+      var provider = aryTmp[0];
+      var newUserId = aryTmp[1];
+      request.post({
+        url: userApiUrl + '/' + originalUser.user_id + '/identities',
+        headers: {
+          Authorization: 'Bearer ' + auth0.accessToken
+        },
+        json: {
+          provider: provider,
+          user_id: newUserId
         }
-      }, function(err) {
-        callback(err, user, context);
+      }, function(err, response, body) {
+        if (response.statusCode >= 400) {
+          return callback(new Error('Error linking account: ' + response.statusMessage));
+        }
+        context.primaryUser = originalUser.user_id;
+        callback(null, user, context);
       });
-    } else {
-      callback(null, user, context);
-    }
-  });
+    });
 }
 ```

--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -11,7 +11,7 @@ This rule will link any accounts that have the same email address.
 > Note: When linking accounts, only the metadata of the target user is saved. If you want to merge the metadata of the two accounts you must do that manually. See the document on [Linking Accounts](https://auth0.com/docs/link-accounts) for more details.
 
 ```js
-function(user, context, callback) {
+function (user, context, callback) {
   var request = require('request@2.56.0');
   // Check if email is verified, we shouldn't automatically
   // merge accounts if this is not the case.
@@ -21,48 +21,48 @@ function(user, context, callback) {
   var userApiUrl = auth0.baseUrl + '/users';
 
   request({
-      url: userApiUrl,
+    url: userApiUrl,
+    headers: {
+      Authorization: 'Bearer ' + auth0.accessToken
+    },
+    qs: {
+      search_engine: 'v2',
+      q: 'email.raw:"' + user.email + '" AND email_verified: "true" -user_id:"' + user.user_id + '"',
+    }
+  },
+  function(err, response, body) {
+    if (err) return callback(err);
+    if (response.statusCode !== 200) return callback(new Error(body));
+
+    var data = JSON.parse(body);
+    if (data.length > 1) {
+      return callback(new Error('[!] Rule: Multiple user profiles already exist - cannot select base profile to link with'));
+    }
+    if (data.length === 0) {
+      console.log('[-] Skipping link rule');
+      return callback(null, user, context);
+    }
+
+    var originalUser = data[0];
+    var aryTmp = user.user_id.split('|');
+    var provider = aryTmp[0];
+    var newUserId = aryTmp[1];
+    request.post({
+      url: userApiUrl + '/' + originalUser.user_id + '/identities',
       headers: {
         Authorization: 'Bearer ' + auth0.accessToken
       },
-      qs: {
-        search_engine: 'v2',
-        q: 'email.raw:"' + user.email + '" AND email_verified: "true" -user_id:"' + user.user_id + '"',
+      json: {
+        provider: provider,
+        user_id: newUserId
       }
-    },
-    function(err, response, body) {
-      if (err) return callback(err);
-      if (response.statusCode !== 200) return callback(new Error(body));
-
-      var data = JSON.parse(body);
-      if (data.length > 1) {
-        return callback(new Error('[!] Rule: Multiple user profiles already exist - cannot select base profile to link with'));
+    }, function(err, response, body) {
+      if (response.statusCode >= 400) {
+        return callback(new Error('Error linking account: ' + response.statusMessage));
       }
-      if (data.length === 0) {
-        console.log('[-] Skipping link rule');
-        return callback(null, user, context);
-      }
-
-      var originalUser = data[0];
-      var aryTmp = user.user_id.split('|');
-      var provider = aryTmp[0];
-      var newUserId = aryTmp[1];
-      request.post({
-        url: userApiUrl + '/' + originalUser.user_id + '/identities',
-        headers: {
-          Authorization: 'Bearer ' + auth0.accessToken
-        },
-        json: {
-          provider: provider,
-          user_id: newUserId
-        }
-      }, function(err, response, body) {
-        if (response.statusCode >= 400) {
-          return callback(new Error('Error linking account: ' + response.statusMessage));
-        }
-        context.primaryUser = originalUser.user_id;
-        callback(null, user, context);
-      });
+      context.primaryUser = originalUser.user_id;
+      callback(null, user, context);
     });
+  });
 }
 ```

--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -44,9 +44,10 @@ function (user, context, callback) {
     }
 
     var originalUser = data[0];
-    var aryTmp = user.user_id.split('|');
-    var provider = aryTmp[0];
-    var newUserId = aryTmp[1];
+    var pipePos = user_id.indexOf('|');
+    var provider = user_id.slice(0, pipePos);
+    var newUserId = user_id.slice(pipePos + 1);
+    
     request.post({
       url: userApiUrl + '/' + originalUser.user_id + '/identities',
       headers: {


### PR DESCRIPTION
If the primary account changes, previously it would cause an error (in the code flow) or an id token with the wrong sub claim (user_id). We added a mechanism to indicate the new primary user ID in a rule to fix this issue.

Customers can set the primary user ID in a rule using `context.primaryUser = 'auth0|foo123'` after account linking.