### PR TITLE
Accept Numeric User-IDs when linking Accounts

### DIFF
--- a/rules/link-users-by-email-with-metadata.md
+++ b/rules/link-users-by-email-with-metadata.md
@@ -61,7 +61,7 @@ function (user, context, callback) {
         headers: {
           Authorization: 'Bearer ' + auth0.accessToken
         },
-        json: { provider: provider, user_id: providerUserId }
+        json: { provider: provider, user_id: String(providerUserId) }
       }, function(err, response, body) {
           if (response && response.statusCode >= 400) {
             return callback(new Error('Error linking account: ' + response.statusMessage));

--- a/rules/link-users-by-email.md
+++ b/rules/link-users-by-email.md
@@ -59,7 +59,7 @@ function (user, context, callback) {
       },
       json: {
         provider: provider,
-        user_id: providerUserId
+        user_id: String(providerUserId)
       }
     }, function(err, response, body) {
       if (response.statusCode >= 400) {


### PR DESCRIPTION
Some Identity-Providers like GitHub provide a `user_id` as an integer. This breaks the assumptions of the `/identities` API. 
This patch ensures saved `user_id` is a string.