### PR TITLE
Update Slack Rule so it's not triggered by refresh token

### DIFF
--- a/rules/slack.md
+++ b/rules/slack.md
@@ -10,8 +10,10 @@ This rule sends a message to a slack channel on every user signup.
 
 ```js
 function(user, context, callback) {
-  // short-circuit if the user signed up already
-  if (context.stats.loginsCount > 1) return callback(null, user, context);
+  // short-circuit if the user signed up already or is using a refresh token
+  if (context.stats.loginsCount > 1 || context.protocol === 'oauth2-refresh-token') {
+    return callback(null, user, context);
+  }
 
   // get your slack's hook url from: https://slack.com/services/10525858050
   var SLACK_HOOK = 'YOUR SLACK HOOK URL';


### PR DESCRIPTION
Fixing as per https://github.com/auth0/docs/pull/5860 :

Use case:
- User requests refresh token during sign up, hence user has registered and authenticated (context.stats.loginsCount is 1), message sent --> OK!
- User uses refresh token to authenticate (context.stats.loginsCount still is 1 since refresh token usage does not count as login), message sent --> WRONG!

Checking for context.protocol === 'oauth2-refresh-token' fixes this issue.