### PR TITLE
Add provider='any' rule for MFA

### DIFF
--- a/rules/mfa.md
+++ b/rules/mfa.md
@@ -16,7 +16,7 @@ function (user, context, callback) {
   1. Client ID:
   context.clientID === 'REPLACE_WITH_YOUR_CLIENT_ID'
   2. User metadata:
-  user_metadata.use_mfa
+  user.user_metadata.use_mfa
   */
 
   // if (<condition>) {

--- a/rules/mfa.md
+++ b/rules/mfa.md
@@ -1,0 +1,34 @@
+---
+gallery: true
+short_description: Trigger multifactor authentication when a condition is met
+categories:
+- multifactor
+---
+
+## Multifactor Authentication
+
+This rule is used to trigger multifactor authentication when a condition is met.
+
+```js
+function (user, context, callback) {
+  /*
+  You can trigger MFA conditionally by checking:
+  1. Client ID:
+  context.clientID === 'REPLACE_WITH_YOUR_CLIENT_ID'
+  2. User metadata:
+  user_metadata.use_mfa
+  */
+
+  // if (<condition>) {
+    context.multifactor = {
+      provider: true,
+
+      // optional, defaults to true. Set to false to force authentication every time.
+      // See https://auth0.com/docs/multifactor-authentication/custom#change-the-frequency-of-authentication-requests for details
+      allowRememberBrowser: false
+    };
+  //}
+
+  callback(null, user, context);
+}
+```

--- a/src/rules/mfa.js
+++ b/src/rules/mfa.js
@@ -13,7 +13,7 @@ function (user, context, callback) {
   1. Client ID:
   context.clientID === 'REPLACE_WITH_YOUR_CLIENT_ID'
   2. User metadata:
-  user_metadata.use_mfa
+  user.user_metadata.use_mfa
   */
 
   // if (<condition>) {

--- a/src/rules/mfa.js
+++ b/src/rules/mfa.js
@@ -1,15 +1,12 @@
----
-gallery: true
-short_description: Trigger multifactor authentication when a condition is met
-categories:
-- multifactor
----
+/**
+ * @overview Trigger multifactor authentication when a condition is met
+ * @gallery true
+ * @category multifactor
+ *
+ * Multifactor Authentication
+ * This rule is used to trigger multifactor authentication when a condition is met.
+ */
 
-## Multifactor Authentication
-
-This rule is used to trigger multifactor authentication when a condition is met.
-
-```js
 function (user, context, callback) {
   /*
   You can trigger MFA conditionally by checking:
@@ -31,4 +28,3 @@ function (user, context, callback) {
 
   callback(null, user, context);
 }
-```

--- a/test/rules/mfa.test.js
+++ b/test/rules/mfa.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const loadRule = require('../utils/load-rule');
+const ContextBuilder = require('../utils/contextBuilder');
+const RequestBuilder = require('../utils/requestBuilder');
+
+const ruleName = 'mfa';
+
+describe(ruleName, () => {
+  let user;
+  let context;
+  let rule;
+
+  beforeEach(() => {
+    rule = loadRule(ruleName);
+
+    const request = new RequestBuilder().build();
+    context = new ContextBuilder()
+      .withRequest(request)
+      .build();
+  });
+
+  it("should set multifactor provider to 'any'", (done) => {
+    rule(user, context, (err, u, c) => {
+      expect(c.multifactor.provider).toBe('any');
+      expect(c.multifactor.allowRememberBrowser).toBe(false);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
We will support specifying `provider = 'any'` in MFA rules to let the server pick the appropriate provider based on dashboard configuration.