### PR TITLE
Update description for check if user email domain matches rule

### DIFF
--- a/rules/check-domains-against-connection-aliases.md
+++ b/rules/check-domains-against-connection-aliases.md
@@ -6,10 +6,11 @@ categories:
 ---
 ## Check user email domain matches domains configured in connection
 
- This rule will check that the email the user has used to login matches any of the domains configured in a connection. If there are no domains configured, it will allow access.
+This rule checks if the user's login email matches any domains configured in an enterprise connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
+
+Use this rule to only allow users from specific email domains to login.
  
- For example, to setup SAML login, a Fabrikam customer must have a managed domain (claimed and verified by the customer). Fabrikam can then enforce a policy where only users belonging to managed email domains should be able to login via SAML. For example, if the customer Contoso has setup contoso.com as a managed domain, only users with email ending @contoso.com (not @contosocorp.com) should be able to login via SAML.
- Because Auth0 doesn't enforce this validation OOB - we have to store the valid email domain in connection object (lock already uses this) and then use a rule to validate incoming user's email domain with the one configured on the connection. If email domains doesn't match, the login is denied.
+For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
 
 ```js
 function (user, context, callback) {

--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -5,9 +5,9 @@
  * 
  * Check user email domain matches domains configured in connection
  * 
- * This rule checks if the user's login email matches any domains configured in a connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
+ * This rule checks if the user's login email matches any domains configured in an enterprise connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
  * 
- * Use this rule to only allow logins from users belonging to managed email domains.
+ * Use this rule to only allow users from specific email domains to login.
  *
  * For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
  */

--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -5,10 +5,11 @@
  * 
  * Check user email domain matches domains configured in connection
  * 
- * This rule will check that the email the user has used to login matches any of the domains configured in a connection. If there are no domains configured, it will allow access.
+ * This rule checks if the user's login email matches any domains configured in a connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
  * 
- * For example, to setup SAML login, a Fabrikam customer must have a managed domain (claimed and verified by the customer). Fabrikam can then enforce a policy where only users belonging to managed email domains should be able to login via SAML. For example, if the customer Contoso has setup contoso.com as a managed domain, only users with email ending @contoso.com (not @contosocorp.com) should be able to login via SAML.
- * Because Auth0 doesn't enforce this validation OOB - we have to store the valid email domain in connection object (lock already uses this) and then use a rule to validate incoming user's email domain with the one configured on the connection. If email domains doesn't match, the login is denied.
+ * Use this rule to only allow logins from users belonging to managed email domains.
+ *
+ * For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
  */
 
 function (user, context, callback) {


### PR DESCRIPTION
> This rule checks if the user's login email matches any domains configured in an enterprise connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
>
> Use this rule to only allow users from specific email domains to login.
> 
> For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.