### PR TITLE
Update check domains rule to account for various cases

### DIFF
--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -12,7 +12,7 @@
  * For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
  */
 
-function (user, context, callback) {
+ function (user, context, callback) {
   const connectionOptions = context.connectionOptions;
   const domainAliases = connectionOptions.domain_aliases || [];
   const tenantDomain = connectionOptions.tenant_domain;
@@ -25,7 +25,7 @@ function (user, context, callback) {
   // Domain aliases exist but no tenant domain exists
   if (domainAliases.length && !tenantDomain) return callback('Access denied');
 
-  let allowedDomains = new Set([tenantDomain]);
+  const allowedDomains = new Set([tenantDomain]);
   domainAliases.forEach(function (alias) {
     if (alias) allowedDomains.add(alias.toLowerCase());
   });

--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -5,27 +5,34 @@
  * 
  * Check user email domain matches domains configured in connection
  * 
- * This rule will check that the email the user has used to login matches any of the domains configured in a connection. If there are no domains configured, it will allow access.
+ * This rule checks if the user's login email matches any domains configured in an enterprise connection. If there are no matches, the login is denied. But, if there are no domains configured it will allow access.
  * 
- * For example, to setup SAML login, a Fabrikam customer must have a managed domain (claimed and verified by the customer). Fabrikam can then enforce a policy where only users belonging to managed email domains should be able to login via SAML. For example, if the customer Contoso has setup contoso.com as a managed domain, only users with email ending @contoso.com (not @contosocorp.com) should be able to login via SAML.
- * Because Auth0 doesn't enforce this validation OOB - we have to store the valid email domain in connection object (lock already uses this) and then use a rule to validate incoming user's email domain with the one configured on the connection. If email domains doesn't match, the login is denied.
+ * Use this rule to only allow users from specific email domains to login.
+ *
+ * For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
  */
 
 function (user, context, callback) {
   const connectionOptions = context.connectionOptions;
-    
+  const domainAliases = connectionOptions.domain_aliases || [];
+  const tenantDomain = connectionOptions.tenant_domain;
+
   // No domains -> access allowed
-  if (!connectionOptions.tenant_domain) {
+  if (!tenantDomain && !domainAliases.length) {
     return callback(null, user, context);
   }
+
+  // Domain aliases exist but no tenant domain exists
+  if (domainAliases.length && !tenantDomain) return callback('Access denied');
+
+  let allowedDomains = new Set([tenantDomain]);
+  domainAliases.forEach(function (alias) {
+    if (alias) allowedDomains.add(alias.toLowerCase());
+  });
   
   // Access allowed if domain is found
   const userEmailDomain = user.email.split('@')[1].toLowerCase();
-  const domainFound = connectionOptions.domain_aliases.some(function (domain) {
-    return userEmailDomain === domain;
-  });
-
-  if (domainFound) return callback(null, user, context);
+  if (allowedDomains.has(userEmailDomain)) return callback(null, user, context);
   
   return callback('Access denied');
 }

--- a/test/rules/check-domains-against-connection-aliases.test.js
+++ b/test/rules/check-domains-against-connection-aliases.test.js
@@ -35,7 +35,7 @@ describe(ruleName, () => {
       rule = loadRule(ruleName, globals);
     });
 
-    it('should allow access', (done) => {      
+    it('should allow access', (done) => {  
       rule(user, context, (e, u, c) => {
         expect(e).toBeNull();
 

--- a/test/rules/check-domains-against-connection-aliases.test.js
+++ b/test/rules/check-domains-against-connection-aliases.test.js
@@ -24,7 +24,7 @@ describe(ruleName, () => {
     };
   });
 
-  describe('when no tenant_domain', () => {
+  describe('when no tenant_domain and no domain_aliases exist', () => {
     beforeEach(() => {
       context = new ContextBuilder()
         .build();
@@ -99,7 +99,53 @@ describe(ruleName, () => {
 
       rule = loadRule(ruleName, globals);
     });
-    it('should not allow access', (done) => {      
+    it('should not allow access', (done) => {
+      rule(user, context, (e, u, c) => {
+        expect(e).toBe('Access denied');
+
+        done();
+      });
+    });
+  });
+
+  describe('matching tenant_domain exists but no domain_aliases exist', () => {
+    beforeEach(() => {
+      context = new ContextBuilder()
+        .withConnectionOptions({
+          tenant_domain: 'contoso.com'
+        })
+        .build();
+
+      user = new UserBuilder()
+        .withEmail('me@contoso.com')
+        .build();
+
+      rule = loadRule(ruleName, globals);
+    });
+    it('should allow access', (done) => {      
+      rule(user, context, (e, u, c) => {
+        expect(e).toBeNull();
+
+        done();
+      });
+    });
+  });
+
+  describe('no tenant_domain exists but domain_aliases is not empty', () => {
+    beforeEach(() => {
+      context = new ContextBuilder()
+        .withConnectionOptions({
+          domain_aliases: ['contoso.com']
+        })
+        .build();
+
+      user = new UserBuilder()
+        .withEmail('me@contoso.com')
+        .build();
+
+      rule = loadRule(ruleName, globals);
+    });
+    it('should not allow access', (done) => {
       rule(user, context, (e, u, c) => {
         expect(e).toBe('Access denied');
 


### PR DESCRIPTION
The rule template and tests have been updated to cover the following 4 scenarios:

- No `tenant_domain` and no `domain_aliases` specified -> allow access
- Tenant domain specified and no domain aliases specified -> check `tenant_domain` for match
- Tenant domain specified and domain aliases specified -> check for match in `tenant_domain` and `domain_aliases`
- No tenant domain specified and domain aliases specified -> reject (this case is odd and shouldn’t exist but we allow it via API2)

Discussed here: https://auth0.slack.com/archives/CBTDY4DJN/p1536589223000100?thread_ts=1536265487.000100&cid=CBTDY4DJN