### PR TITLE
Protect against malicious emails

### DIFF
--- a/rules/check-domains-against-connection-aliases.md
+++ b/rules/check-domains-against-connection-aliases.md
@@ -13,7 +13,7 @@ Use this rule to only allow users from specific email domains to login.
 For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
 
 ```js
-function (user, context, callback) {
+ function (user, context, callback) {
   const connectionOptions = context.connectionOptions;
   const domainAliases = connectionOptions.domain_aliases || [];
   const tenantDomain = connectionOptions.tenant_domain;
@@ -26,13 +26,14 @@ function (user, context, callback) {
   // Domain aliases exist but no tenant domain exists
   if (domainAliases.length && !tenantDomain) return callback('Access denied');
 
-  let allowedDomains = new Set([tenantDomain]);
+  const allowedDomains = new Set([tenantDomain]);
   domainAliases.forEach(function (alias) {
     if (alias) allowedDomains.add(alias.toLowerCase());
   });
   
   // Access allowed if domain is found
-  const userEmailDomain = user.email.split('@')[1].toLowerCase();
+  const emailSplit = user.email.split('@');
+  const userEmailDomain = emailSplit[emailSplit.length - 1].toLowerCase();
   if (allowedDomains.has(userEmailDomain)) return callback(null, user, context);
   
   return callback('Access denied');

--- a/rules/check-domains-against-connection-aliases.md
+++ b/rules/check-domains-against-connection-aliases.md
@@ -13,7 +13,7 @@ Use this rule to only allow users from specific email domains to login.
 For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
 
 ```js
- function (user, context, callback) {
+function (user, context, callback) {
   const connectionOptions = context.connectionOptions;
   const domainAliases = connectionOptions.domain_aliases || [];
   const tenantDomain = connectionOptions.tenant_domain;

--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -31,7 +31,8 @@
   });
   
   // Access allowed if domain is found
-  const userEmailDomain = user.email.split('@')[1].toLowerCase();
+  const emailSplit = user.email.split('@');
+  const userEmailDomain = emailSplit[emailSplit.length - 1].toLowerCase();
   if (allowedDomains.has(userEmailDomain)) return callback(null, user, context);
   
   return callback('Access denied');

--- a/test/rules/check-domains-against-connection-aliases.test.js
+++ b/test/rules/check-domains-against-connection-aliases.test.js
@@ -86,6 +86,27 @@ describe(ruleName, () => {
     });
   });
 
+  describe('when email domain is not an exact match', () => {
+    beforeEach(() => {
+      context = new ContextBuilder()
+        .withConnectionOptions(connectionOptions)
+        .build();
+
+      user = new UserBuilder()
+        .withEmail('rikaard.hosein”@contoso.com@whatever”@gmail.com')
+        .build();
+
+      rule = loadRule(ruleName, globals);
+    });
+    it('should split the domain correctly and not allow access', (done) => {      
+      rule(user, context, (e, u, c) => {
+        expect(e).toBe('Access denied');
+
+        done();
+      });
+    });
+  });
+
   describe('when no tenant_domain or email matching domain alias exists', () => {
     beforeEach(() => {
       context = new ContextBuilder()


### PR DESCRIPTION
According to the spec, the following emails are valid:

- `attacker”@microsoft.com@whatever”@gmail.com`
- `"very.(),:;<>[]\".VERY.\"very@\\ \"very\".unusual"@strange.example.com`

For `attacker”@microsoft.com@whatever”@gmail.com`. The current rule would allow `microsoft.com`.