### PR TITLE
Remove admin property references from duo rule

### DIFF
--- a/src/rules/duo-multifactor.js
+++ b/src/rules/duo-multifactor.js
@@ -31,13 +31,7 @@ function (user, context, callback) {
         allowRememberBrowser: false,
 
         // optional. Use some attribute of the profile as the username in DuoSecurity. This is also useful if you already have your users enrolled in Duo.
-        // username: user.nickname,
-
-        // optional. Admin credentials. If you provide an Admin SDK type of credentials. auth0 will update the realname and email in DuoSecurity.
-        // admin: {
-        //  ikey: configuration.DUO_ADMIN_IKEY,
-        //  skey: configuration.DUO_ADMIN_SKEY
-        // },
+        // username: user.nickname
       };
     // }
   }


### PR DESCRIPTION
`admin` props are not being honored for DUO, remove them from the sample rule. A separate PR was sent to remove it from docs already: https://github.com/auth0/docs/pull/6891.