### PR TITLE
Fixing "Date is not defined"error

### DIFF
--- a/src/rules/access-on-weekdays-only-for-an-app.js
+++ b/src/rules/access-on-weekdays-only-for-an-app.js
@@ -11,7 +11,8 @@
 function (user, context, callback) {
 
   if (context.clientName === 'TheAppToCheckAccessTo') {
-    const d = Date.getDay();
+    const date = new Date();
+    const d = date.getDay();
 
     if (d === 0 || d === 6) {
       return callback(new UnauthorizedError('This app is available during the week'));

--- a/test/rules/access-on-weekdays-only-for-an-app.test.js
+++ b/test/rules/access-on-weekdays-only-for-an-app.test.js
@@ -23,7 +23,7 @@ describe(ruleName, () => {
 
   describe('when day is weekend', () => {
     beforeEach(() => {
-      global.Date.getDay = jest.genMockFunction().mockReturnValue(6);
+      global.Date.prototype.getDay = jest.genMockFunction().mockReturnValue(6);
     })
     it('should return UnauthorizedError', (done) => {
       rule(user, context, (err, user, context) => {
@@ -34,7 +34,7 @@ describe(ruleName, () => {
   })
   describe('when day is week day', () => {
     beforeEach(() => {
-      global.Date.getDay = jest.genMockFunction().mockReturnValue(3);
+      global.Date.prototype.getDay = jest.genMockFunction().mockReturnValue(3);
     })
     it('should return no error', (done) => {
       rule(user, context, (err, cbUser, cbContext) => {


### PR DESCRIPTION
Currently, the template rule generates this error:

```
Code generated an uncaught exception: ReferenceError: Date is not defined
at /data/io/9a9b825b-0330-452d-ac73-7a70ed44bbe7/webtask.js:34:22
at fn (/data/sandbox/node_modules/auth0-authz-rules-api/node_modules/async/lib/async.js:638:34)
at Immediate._onImmediate (/data/sandbox/node_modules/auth0-authz-rules-api/node_modules/async/lib/async.js:554:34)
at processImmediate [as _immediateCallback] (timers.js:396:17)
```

Which ends up with the Rule throwing a 500 Internal Server Error.

This patch defines the `date` variable to use the `Date()` function, and then references it in the following statement. This has been tested and works as expected.