### PR TITLE
Update zapier-new-user.js

### DIFF
--- a/src/rules/zapier-new-user.js
+++ b/src/rules/zapier-new-user.js
@@ -21,7 +21,7 @@ function (user, context, callback) {
   }
 
   const MY_SLACK_WEBHOOK_URL = 'YOUR SLACK WEBHOOK URL';
-  const slack = require('slack-notify')(MY_SLACK_WEBHOOK_URL);
+  const slack = require('slack-notify@0.1.4')(MY_SLACK_WEBHOOK_URL);
 
   const request = require('request');
 


### PR DESCRIPTION
Switch from using context.loginsCount to a more reliable metadata flag.
context.loginsCount can be incremented without rules being run some scenarios (like failed cross-origin authentication or execution canceled by other rules), so using a metadata flag instead makes the check more reliable.