### PR TITLE
ESD 2054: Remove illegal characters from rule titles

### DIFF
--- a/src/rules/get-towerdata-profile.js
+++ b/src/rules/get-towerdata-profile.js
@@ -1,5 +1,5 @@
 /**
- * @title Enrich profile with Towerdata (formerly RapLeaf)
+ * @title Enrich profile with Towerdata - formerly RapLeaf
  * @overview Get user information from towerdata (formerly rapleaf) using email and add towerdata property to user profile.
  * @gallery true
  * @category enrich profile

--- a/src/rules/guardian-multifactor-authorization-extension.js
+++ b/src/rules/guardian-multifactor-authorization-extension.js
@@ -1,5 +1,5 @@
 /**
- * @title Multifactor with Auth0 Guardian + Authorization Extension
+ * @title Multifactor with Auth0 Guardian and Authorization Extension
  * @overview Guardian mfa + authorization extension working together.
  * @gallery true
  * @category multifactor,guardian

--- a/src/rules/migrate-root-attributes.js
+++ b/src/rules/migrate-root-attributes.js
@@ -1,5 +1,5 @@
 /**
- * @title Move user metadata attributes to profile root attributes.
+ * @title Move user metadata attributes to profile root attributes
  * @overview Moves select data from user_metadata to profile root attributes (family_name, given_name, name, nickname and picture).
  * @gallery true
  * @category enrich profile

--- a/src/rules/migrate-root-attributes.js
+++ b/src/rules/migrate-root-attributes.js
@@ -1,5 +1,5 @@
 /**
- * @title Move user_metadata attributes to profile root attributes.
+ * @title Move user metadata attributes to profile root attributes.
  * @overview Moves select data from user_metadata to profile root attributes (family_name, given_name, name, nickname and picture).
  * @gallery true
  * @category enrich profile

--- a/src/rules/pusher.js
+++ b/src/rules/pusher.js
@@ -1,6 +1,6 @@
 /**
- * @title Obtains a Pusher token for subscribing/publishing to private channels
- * @overview Obtain a Pusher token for subscribing/publishing to private channels.
+ * @title Obtain a Pusher token for subscribing and publishing to private channels
+ * @overview Obtains a Pusher token for subscribing/publishing to private channels.
  * @gallery true
  * @category webhook
  *

--- a/src/rules/send-events-segmentio.js
+++ b/src/rules/send-events-segmentio.js
@@ -1,5 +1,5 @@
 /**
- * @title Send events to Segment 
+ * @title Send events to Segment IO
  * @overview Send events to segment.io
  * @gallery false
  * @category webhook

--- a/src/rules/send-events-segmentio.js
+++ b/src/rules/send-events-segmentio.js
@@ -1,5 +1,5 @@
 /**
- * @title Send events to segment.io
+ * @title Send events to Segment 
  * @overview Send events to segment.io
  * @gallery false
  * @category webhook

--- a/src/rules/splunk-HEC-track-event.js
+++ b/src/rules/splunk-HEC-track-event.js
@@ -1,5 +1,5 @@
 /**
- * @title Tracks Logins/SignUps with Splunk HEC
+ * @title Tracks Logins and Signups with Splunk HEC
  * @overview Send SignUp and Login events to Splunk's [HTTP Event Collector] (http://dev.splunk.com/view/event-collector/SP-CAAAE7F), including some contextual information of the user.
  * @gallery true
  * @category webhook


### PR DESCRIPTION
### Description

Several rules contain characters in their @title attributes that are not allowed. If a user tries to create a rule from one of these templates, they receive the error: `The name of the rule. Can only contain alphanumeric characters, spaces and '-'. Can neither start nor end with '-' or spaces`. 

### References

https://auth0team.atlassian.net/browse/ESD-2054

### Testing

- [  x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [  x ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ✓ ] All active GitHub checks for tests, formatting, and security are passing
- [ ✓ ] The correct base branch is being used, if not `master`
