### PR TITLE
ESD-2054: Update rules.json to remove illegal characters from rule titles

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -249,7 +249,7 @@
       },
       {
         "id": "get-towerdata-profile",
-        "title": "Enrich profile with Towerdata (formerly RapLeaf)",
+        "title": "Enrich profile with Towerdata - formerly RapLeaf",
         "overview": "Get user information from towerdata (formerly rapleaf) using email and add towerdata property to user profile.",
         "categories": [
           "enrich profile"
@@ -279,7 +279,7 @@
       },
       {
         "id": "migrate-root-attributes",
-        "title": "Move user_metadata attributes to profile root attributes.",
+        "title": "Move user metadata attributes to profile root attributes",
         "overview": "Moves select data from user_metadata to profile root attributes (family_name, given_name, name, nickname and picture).",
         "categories": [
           "enrich profile"
@@ -395,7 +395,7 @@
       },
       {
         "id": "pusher",
-        "title": "Obtains a Pusher token for subscribing/publishing to private channels",
+        "title": "Obtains a Pusher token for subscribing and publishing to private channels",
         "overview": "Obtain a Pusher token for subscribing/publishing to private channels.",
         "categories": [
           "webhook"
@@ -435,7 +435,7 @@
       },
       {
         "id": "splunk-HEC-track-event",
-        "title": "Tracks Logins/SignUps with Splunk HEC",
+        "title": "Tracks Logins and SignUps with Splunk HEC",
         "overview": "Send SignUp and Login events to Splunk's [HTTP Event Collector] (http://dev.splunk.com/view/event-collector/SP-CAAAE7F), including some contextual information of the user.",
         "categories": [
           "webhook"
@@ -490,7 +490,7 @@
       },
       {
         "id": "guardian-multifactor-authorization-extension",
-        "title": "Multifactor with Auth0 Guardian + Authorization Extension",
+        "title": "Multifactor with Auth0 Guardian and Authorization Extension",
         "overview": "Guardian mfa + authorization extension working together.",
         "categories": [
           "multifactor",
@@ -548,7 +548,7 @@
     "templates": [
       {
         "id": "guardian-multifactor-authorization-extension",
-        "title": "Multifactor with Auth0 Guardian + Authorization Extension",
+        "title": "Multifactor with Auth0 Guardian and Authorization Extension",
         "overview": "Guardian mfa + authorization extension working together.",
         "categories": [
           "multifactor",


### PR DESCRIPTION
## Description
Several rules contain characters in their @title attributes that are not allowed. If a user tries to create a rule from one of these templates, they receive the error: The name of the rule. Can only contain alphanumeric characters, spaces and '-'. Can neither start nor end with '-' or spaces.

## References
https://auth0team.atlassian.net/browse/ESD-2054

## Testing
[ x ] This change adds test coverage for new/changed/fixed functionality

## Checklist
[ x ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
[ ✓ ] All active GitHub checks for tests, formatting, and security are passing
[ ✓ ] The correct base branch is being used, if not master