### PR TITLE
[DXEX-458] Remove magic global references from rule templates.

### DIFF
--- a/redirect-rules/active-directory-pwd-reset-policy/rule.js
+++ b/redirect-rules/active-directory-pwd-reset-policy/rule.js
@@ -1,4 +1,5 @@
 function activeDirectoryPasswordResetPolicy(user, context, callback) {
+  const jwt = require('jsonwebtoken');
 
   if (context.connection !== 'FabrikamAD') {
     return callback(null, user, context);

--- a/redirect-rules/active-directory-pwd-reset-policy/rule.js
+++ b/redirect-rules/active-directory-pwd-reset-policy/rule.js
@@ -1,4 +1,4 @@
-function (user, context, callback) {
+function activeDirectoryPasswordResetPolicy(user, context, callback) {
 
   if (context.connection !== 'FabrikamAD') {
     return callback(null, user, context);

--- a/redirect-rules/progressive-profiling/continue-from-update-profile-website.js
+++ b/redirect-rules/progressive-profiling/continue-from-update-profile-website.js
@@ -1,4 +1,4 @@
-function rule (user, context, callback) {
+function continueFromUpdateProfileWebsite(user, context, callback) {
   const _ = require('lodash');
   const RULE_NAME = 'continue-from-update-profile-website';
     

--- a/redirect-rules/progressive-profiling/redirect-to-update-profile-website.js
+++ b/redirect-rules/progressive-profiling/redirect-to-update-profile-website.js
@@ -1,4 +1,4 @@
-function rule (user, context, callback) {
+function redirectToUpdateProfileWebsite(user, context, callback) {
   const RULE_NAME = 'redirect-to-update-profile-website';
   const jwt = require('jsonwebtoken');
 

--- a/redirect-rules/simple/rule.js
+++ b/redirect-rules/simple/rule.js
@@ -1,4 +1,4 @@
-function redirectToConsentForm (user, context, callback) {
+function redirectToConsentForm(user, context, callback) {
   var hasConsented = user.app_metadata && user.app_metadata.has_consented;
 
   // redirect to consent form if user has not yet consented

--- a/src/rules/access-on-weekdays-only-for-an-app.js
+++ b/src/rules/access-on-weekdays-only-for-an-app.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function accessOnWeekdaysOnly(user, context, callback) {
 
   if (context.clientName === 'TheAppToCheckAccessTo') {
     const date = new Date();

--- a/src/rules/active-directory-groups.js
+++ b/src/rules/active-directory-groups.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+  function activeDirectoryGroups(user, context, callback) {
   var groupAllowed = 'group1';
   if (user.groups) {
     var userHasAccess = user.groups.some(

--- a/src/rules/add-attributes.js
+++ b/src/rules/add-attributes.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function addAttributes(user, context, callback) {
   if (context.connection === 'company.com') {
     context.idToken['https://example.com/vip'] = true;
   }

--- a/src/rules/add-country.js
+++ b/src/rules/add-country.js
@@ -24,7 +24,7 @@
  *
  */
 
-function (user, context, callback) {
+function addCountry(user, context, callback) {
   if (context.request.geoip) {
     context.idToken['https://example.com/country'] = context.request.geoip.country_name;
     context.idToken['https://example.com/timezone'] = context.request.geoip.time_zone;

--- a/src/rules/add-persistence-attribute.js
+++ b/src/rules/add-persistence-attribute.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function addPersistenceAttribute(user, context, callback) {
   user.user_metadata = user.user_metadata || {};
   user.user_metadata.color = user.user_metadata.color || 'blue';
   context.idToken['https://example.com/favorite_color'] = user.user_metadata.color;

--- a/src/rules/add-roles-from-sqlserver.js
+++ b/src/rules/add-roles-from-sqlserver.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function addRolesFromSqlServer(user, context, callback) {
 
   // Roles should only be set to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/add-roles-from-sqlserver.js
+++ b/src/rules/add-roles-from-sqlserver.js
@@ -11,6 +11,7 @@
  */
 
 function addRolesFromSqlServer(user, context, callback) {
+  const tedious = require('tedious');
 
   // Roles should only be set to verified users.
   if (!user.email || !user.email_verified) {
@@ -27,7 +28,7 @@ function addRolesFromSqlServer(user, context, callback) {
 
   // Queries a table by e-mail and returns associated 'Roles'
   function getRoles(email, done) {
-    const connection = sqlserver.connect({
+    const connection = new tedious.Connection({
       userName: configuration.SQL_DATABASE_USERNAME,
       password: configuration.SQL_DATABASE_PASSWORD,
       server:   configuration.SQL_DATABASE_HOSTNAME,
@@ -45,7 +46,7 @@ function addRolesFromSqlServer(user, context, callback) {
     connection.on('connect', (err) => {
       if (err) return done(new Error(err));
 
-      const request = new sqlserver.Request(query, (err, rowCount, rows) => {
+      const request = new tedious.Request(query, (err, rowCount, rows) => {
         if (err) return done(new Error(err));
 
         const roles = rows.map((row) => {
@@ -55,7 +56,7 @@ function addRolesFromSqlServer(user, context, callback) {
         done(null, roles);
       });
 
-      request.addParameter('email', sqlserver.Types.VarChar, email);
+      request.addParameter('email', tedious.TYPES.VarChar, email);
 
       connection.execSql(request);
     });

--- a/src/rules/appery.js
+++ b/src/rules/appery.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function generateApperySessionToken(user, context, callback) {
   // run this only for the Appery.io application
   // if (context.clientID !== 'APPERYIO CLIENT ID IN AUTH0') return callback(null, user, context);
 

--- a/src/rules/appery.js
+++ b/src/rules/appery.js
@@ -13,6 +13,8 @@
  */
 
 function generateApperySessionToken(user, context, callback) {
+  const request = require('request');
+
   // run this only for the Appery.io application
   // if (context.clientID !== 'APPERYIO CLIENT ID IN AUTH0') return callback(null, user, context);
 

--- a/src/rules/aspnet-webapi.js
+++ b/src/rules/aspnet-webapi.js
@@ -18,7 +18,7 @@
  *
  */
 
-function (user, context, callback) {
+function aspnetWebApi(user, context, callback) {
   user.app_metadata = user.app_metadata || {};
   if (user.app_metadata.customId) {
     console.log('Found ID!');

--- a/src/rules/aspnet-webapi.js
+++ b/src/rules/aspnet-webapi.js
@@ -19,6 +19,8 @@
  */
 
 function aspnetWebApi(user, context, callback) {
+  const request = require('request');
+
   user.app_metadata = user.app_metadata || {};
   if (user.app_metadata.customId) {
     console.log('Found ID!');

--- a/src/rules/check-domains-against-connection-aliases.js
+++ b/src/rules/check-domains-against-connection-aliases.js
@@ -11,7 +11,7 @@
  * For example, ExampleCo has setup exampleco.com as a managed domain. They add exampleco.com to the email domains list in their SAML connection. Now, only users with an email ending with @exampleco.com (and not @examplecocorp.com) can login via SAML.
  */
 
-function (user, context, callback) {
+function checkDomainsAgainstConnectionAliases(user, context, callback) {
   const connectionOptions = context.connectionOptions;
   const domainAliases = connectionOptions.domain_aliases || [];
   const tenantDomain = connectionOptions.tenant_domain;

--- a/src/rules/check-last-password-reset.js
+++ b/src/rules/check-last-password-reset.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function checkLastPasswordReset(user, context, callback) {
   function daydiff (first, second) {
     return (second-first)/(1000*60*60*24);
   }

--- a/src/rules/creates-lead-salesforce.js
+++ b/src/rules/creates-lead-salesforce.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function createLeadSalesforce(user, context, callback) {
   user.app_metadata = user.app_metadata || {};
   if (user.app_metadata.recordedAsLead) {
     return callback(null,user,context);

--- a/src/rules/creates-lead-salesforce.js
+++ b/src/rules/creates-lead-salesforce.js
@@ -18,6 +18,8 @@ function createLeadSalesforce(user, context, callback) {
     return callback(null,user,context);
   }
 
+  const request = require('request');
+
   const MY_SLACK_WEBHOOK_URL = 'YOUR SLACK WEBHOOK URL';
   const slack = require('slack-notify')(MY_SLACK_WEBHOOK_URL);
 

--- a/src/rules/default-picture-null-avatars.js
+++ b/src/rules/default-picture-null-avatars.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function defaultPictureForNullAvatars(user, context, callback) {
   if (user.picture.indexOf('cdn.auth0.com') > -1) {
     const url = require('url');
     const u = url.parse(user.picture, true);

--- a/src/rules/disable-resource-owner.js
+++ b/src/rules/disable-resource-owner.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function disableResourceOwner(user, context, callback) {
   if (context.protocol === 'oauth2-resource-owner') {
     return callback(
       new UnauthorizedError('The resource owner endpoint cannot be used.'));

--- a/src/rules/disable-social-signup.js
+++ b/src/rules/disable-social-signup.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function disableSocialSignups(user, context, callback) {
 
   const CLIENTS_ENABLED = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients

--- a/src/rules/dropbox-whitelist.js
+++ b/src/rules/dropbox-whitelist.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function dropboxWhitelist(user, context, callback) {
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/dropbox-whitelist.js
+++ b/src/rules/dropbox-whitelist.js
@@ -9,6 +9,7 @@
  */
 
 function dropboxWhitelist(user, context, callback) {
+  const request = require('request');
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/duo-multifactor.js
+++ b/src/rules/duo-multifactor.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function duoMultifactor(user, context, callback) {
 
   var CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
   // run only for the specified clients

--- a/src/rules/email-verified.js
+++ b/src/rules/email-verified.js
@@ -15,7 +15,7 @@
  *
  */
 
-function (user, context, callback) {
+function emailVerified(user, context, callback) {
   if (!user.email_verified) {
     return callback(new UnauthorizedError('Please verify your email before logging in.'));
   } else {

--- a/src/rules/facebook-custom-picture.js
+++ b/src/rules/facebook-custom-picture.js
@@ -9,6 +9,8 @@
  */
 
 function facebookCustomPicture(user, context, callback) {
+  const _ = require('lodash');
+
   if (context.connection === 'facebook') {
     const fbIdentity = _.find(user.identities, { connection: 'facebook' });
     // for more sizes and types of images that can be returned, see:

--- a/src/rules/facebook-custom-picture.js
+++ b/src/rules/facebook-custom-picture.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function facebookCustomPicture(user, context, callback) {
   if (context.connection === 'facebook') {
     const fbIdentity = _.find(user.identities, { connection: 'facebook' });
     // for more sizes and types of images that can be returned, see:

--- a/src/rules/fraud-prevention-with-minfraud.js
+++ b/src/rules/fraud-prevention-with-minfraud.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function fraudPrevention(user, context, callback) {
   const querystring = require('querystring');
   const request = require('request');
   const crypto = require('crypto');

--- a/src/rules/get-fullcontact-profile.js
+++ b/src/rules/get-fullcontact-profile.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function getFullContactProfile(user, context, callback) {
   const FULLCONTACT_KEY = configuration.FULLCONTACT_KEY;
   const SLACK_HOOK = configuration.SLACK_HOOK_URL;
 

--- a/src/rules/get-fullcontact-profile.js
+++ b/src/rules/get-fullcontact-profile.js
@@ -16,6 +16,7 @@ function getFullContactProfile(user, context, callback) {
   const FULLCONTACT_KEY = configuration.FULLCONTACT_KEY;
   const SLACK_HOOK = configuration.SLACK_HOOK_URL;
 
+  const request = require('request');
   const slack = require('slack-notify')(SLACK_HOOK);
 
   // skip if no email

--- a/src/rules/get-getIP.js
+++ b/src/rules/get-getIP.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function getIp(user, context, callback) {
 
   user.user_metadata = user.user_metadata || {};
 

--- a/src/rules/get-towerdata-profile.js
+++ b/src/rules/get-towerdata-profile.js
@@ -13,6 +13,7 @@
  */
 
 function getTowerdataProfile(user, context, callback) {
+  const request = require('request');
 
   //Filter by app
   //if(context.clientName !== 'AN APP') return callback(null, user, context);

--- a/src/rules/get-towerdata-profile.js
+++ b/src/rules/get-towerdata-profile.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function getTowerdataProfile(user, context, callback) {
 
   //Filter by app
   //if(context.clientName !== 'AN APP') return callback(null, user, context);

--- a/src/rules/get-twitter-email.js
+++ b/src/rules/get-twitter-email.js
@@ -26,12 +26,14 @@ function getTwitterEmail(user, context, callback) {
     return callback(null, user, context);
   }
 
+  const request = require('request');
   const oauth = require('oauth-sign');
   const uuid = require('uuid');
 
   const url = 'https://api.twitter.com/1.1/account/verify_credentials.json';
   const consumerKey = configuration.TWITTER_CONSUMER_KEY;
   const consumerSecretKey = configuration.TWITTER_CONSUMER_SECRET_KEY;
+
 
   const twitterIdentity = _.find(user.identities, { connection: 'twitter' });
   const oauthToken = twitterIdentity.access_token;

--- a/src/rules/get-twitter-email.js
+++ b/src/rules/get-twitter-email.js
@@ -20,7 +20,7 @@
  *
  */
 
-function (user, context, callback) {
+function getTwitterEmail(user, context, callback) {
   // additional request below is specific to Twitter
   if (context.connectionStrategy !== 'twitter') {
     return callback(null, user, context);

--- a/src/rules/get-twitter-email.js
+++ b/src/rules/get-twitter-email.js
@@ -35,7 +35,6 @@ function getTwitterEmail(user, context, callback) {
   const consumerKey = configuration.TWITTER_CONSUMER_KEY;
   const consumerSecretKey = configuration.TWITTER_CONSUMER_SECRET_KEY;
 
-
   const twitterIdentity = _.find(user.identities, { connection: 'twitter' });
   const oauthToken = twitterIdentity.access_token;
   const oauthTokenSecret = twitterIdentity.access_token_secret;

--- a/src/rules/get-twitter-email.js
+++ b/src/rules/get-twitter-email.js
@@ -26,6 +26,7 @@ function getTwitterEmail(user, context, callback) {
     return callback(null, user, context);
   }
 
+  const _ = require('lodash');
   const request = require('request');
   const oauth = require('oauth-sign');
   const uuid = require('uuid');

--- a/src/rules/guardian-multifactor-authorization-extension.js
+++ b/src/rules/guardian-multifactor-authorization-extension.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function guardianMultifactorAuthorization(user, context, callback) {
   if (!user.app_metadata || !user.app_metadata.authorization ||
     !Array.isArray(user.app_metadata.authorization.groups)) {
     return callback(null, user, context);

--- a/src/rules/guardian-multifactor-ip-range.js
+++ b/src/rules/guardian-multifactor-ip-range.js
@@ -7,7 +7,7 @@
  * This rule is used to trigger multifactor authentication when the requesting IP is from outside the corporate IP range.
  */
 
-function (user, context, callback) {
+function guardianMultifactorIpRange(user, context, callback) {
   const ipaddr = require('ipaddr.js');
   const corp_network = "192.168.1.134/26";
   const current_ip = ipaddr.parse(context.request.ip);

--- a/src/rules/guardian-multifactor.js
+++ b/src/rules/guardian-multifactor.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function guardianMultifactor(user, context, callback) {
   //const CLIENTS_WITH_MFA = ['REPLACE_WITH_YOUR_CLIENT_ID'];
 
   // run only for the specified clients

--- a/src/rules/intercom-user.js
+++ b/src/rules/intercom-user.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function intercomUser(user, context, callback) {
   const request = require('request');
   const moment = require('moment-timezone');
 

--- a/src/rules/ip-address-whitelist.js
+++ b/src/rules/ip-address-whitelist.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function ipAddressWhitelist(user, context, callback) {
   const whitelist = ['1.2.3.4', '2.3.4.5']; // authorized IPs
   const userHasAccess = whitelist.some(function (ip) {
     return context.request.ip === ip;

--- a/src/rules/jwt.js
+++ b/src/rules/jwt.js
@@ -7,7 +7,7 @@
  *
  */
 
-function (user, context, callback) {
+function generateJwt(user, context, callback) {
   const jwt = require('jsonwebtoken');
   const CLIENT_SECRET = configuration.TARGET_API_CLIENT_SECRET;
   const CLIENT_ID = configuration.TARGET_API_CLIENT_ID;

--- a/src/rules/link-users-by-email-with-metadata.js
+++ b/src/rules/link-users-by-email-with-metadata.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function linkUsersByEmailWithMetadata(user, context, callback) {
   const request = require('request');
   const _ = require('lodash');
 

--- a/src/rules/link-users-by-email.js
+++ b/src/rules/link-users-by-email.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function linkUsersByEmail(user, context, callback) {
   const request = require('request');
   // Check if email is verified, we shouldn't automatically
   // merge accounts if this is not the case.

--- a/src/rules/linkedin-original-picture.js
+++ b/src/rules/linkedin-original-picture.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function useOriginallinkedInProfilePicture(user, context, callback) {
   if (context.connection !== 'linkedin') {
     return callback(null, user, context);
   }

--- a/src/rules/linkedin-original-picture.js
+++ b/src/rules/linkedin-original-picture.js
@@ -13,6 +13,7 @@ function useOriginallinkedInProfilePicture(user, context, callback) {
     return callback(null, user, context);
   }
 
+  const _ = require('lodash');
   const request = require('request');
 
   const liIdentity = _.find(user.identities, { connection: 'linkedin' });

--- a/src/rules/mailgun.js
+++ b/src/rules/mailgun.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function sendMailgunEmail(user, context, callback) {
   user.app_metadata = user.app_metadata || {};
 
   if (user.app_metadata.signedUp) {

--- a/src/rules/mandrill.js
+++ b/src/rules/mandrill.js
@@ -14,7 +14,7 @@
  *
  */
 
-function (user, context, callback) {
+function sendMandrillEmail(user, context, callback) {
   const request = require('request');
 
   user.app_metadata = user.app_metadata || {};

--- a/src/rules/mfa.js
+++ b/src/rules/mfa.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function multifactorAuthentication(user, context, callback) {
   /*
   You can trigger MFA conditionally by checking:
   1. Client ID:

--- a/src/rules/migrate-root-attributes.js
+++ b/src/rules/migrate-root-attributes.js
@@ -13,7 +13,7 @@
  * 2- The mapped fields from user_metadata will be removed following the update.
  * 3- This rule will be executed on each login event. For signup scenarios, you should only consider using this rule if you currently use a custom signup form or Authentication Signup API, as these signup methods do not support setting the root attributes.
  */
-function (user, context, cb) {
+function migrateRootAttributes(user, context, cb) {
   // Field Mapping, the property is the root attribute and the value is the field name on user_metadata.
   // You can change the value in case you don't have the same name on user_metadata.
   var fieldMapping = {

--- a/src/rules/mixpanel-track-event.js
+++ b/src/rules/mixpanel-track-event.js
@@ -11,6 +11,7 @@
  */
 
 function trackLoginInMixPanel(user, context, callback) {
+  const request = require('request');
 
   const mpEvent = {
     "event": "Sign In",

--- a/src/rules/mixpanel-track-event.js
+++ b/src/rules/mixpanel-track-event.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function trackLoginInMixPanel(user, context, callback) {
 
   const mpEvent = {
     "event": "Sign In",

--- a/src/rules/mongodb.js
+++ b/src/rules/mongodb.js
@@ -8,9 +8,15 @@
  */
 
 function enrichProfileWithMongo(user, context, callback) {
-  const connection_string = configuration.MONGO_CONNECTION_STRING;
-  mongo(connection_string, function (db) {
+  const MongoClient = require('mongodb@3.1.4').MongoClient;
+  const mongoUrl = configuration.MONGO_CONNECTION_STRING;
+
+  MongoClient.connect(mongoUrl, { useNewUrlParser: true }, function(err, client) {
+    if (err) return callback(err);
+
+    const db = client.db('YOUR_MONGO_DATABASE_NAME');
     const users = db.collection('users');
+
     users.findOne({email: user.email}, function (err, mongoUser) {
       if (err) return callback(err);
       if (!mongoUser) return callback(null, user, context);

--- a/src/rules/mongodb.js
+++ b/src/rules/mongodb.js
@@ -7,7 +7,7 @@
  *
  */
 
-function (user, context, callback) {
+function enrichProfileWithMongo(user, context, callback) {
   const connection_string = configuration.MONGO_CONNECTION_STRING;
   mongo(connection_string, function (db) {
     const users = db.collection('users');

--- a/src/rules/parse.js
+++ b/src/rules/parse.js
@@ -13,7 +13,7 @@
  *
  */
 
-function (user, context, callback) {
+function generateParseSessionToken(user, context, callback) {
   // run this only for the Parse application
   // if (context.clientID !== 'PARSE CLIENT ID IN AUTH0') return callback(null, user, context);
 

--- a/src/rules/pusher.js
+++ b/src/rules/pusher.js
@@ -8,7 +8,9 @@
  *
  */
 
-function (user, context, callback) {
+function getPusherToken(user, context, callback) {
+  const crypto = require('crypto');
+
   const pusherKey = configuration.PUSHER_KEY;
   const pusherSecret = configuration.PUSHER_SECRET;
 

--- a/src/rules/querystring.js
+++ b/src/rules/querystring.js
@@ -14,7 +14,7 @@
  *
  */
 
-function (user, context, callback) {
+function useQuerystring(user, context, callback) {
   if (context.request.query.some_querystring === 'whatever') {
     context.idToken['https://example.com/new_attribute'] = 'foo';
   }

--- a/src/rules/remove-attributes.js
+++ b/src/rules/remove-attributes.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function removeUserAttribute(user, context, callback) {
   const blacklist = [ 'some_attribute' ];
 
   Object.keys(user).forEach(function(key) {

--- a/src/rules/requestbin.js
+++ b/src/rules/requestbin.js
@@ -15,6 +15,7 @@
  */
 
 function sendVariablesToRequestBin(user, context, callback) {
+  const _ = require('lodash');
   const request = require('request');
 
   // https://auth0.com/docs/user-profile/user-profile-structure

--- a/src/rules/requestbin.js
+++ b/src/rules/requestbin.js
@@ -14,7 +14,7 @@
  *
  */
 
-function (user, context, callback) {
+function sendVariablesToRequestBin(user, context, callback) {
   const request = require('request');
 
   // https://auth0.com/docs/user-profile/user-profile-structure

--- a/src/rules/require-mfa-once-per-session.js
+++ b/src/rules/require-mfa-once-per-session.js
@@ -10,7 +10,7 @@
  *
  */
 
-function (user, context, callback) {
+function requireMfaOncePerSession(user, context, callback) {
   const completedMfa = !!context.authentication.methods.find(
     (method) => method.name === 'mfa'
   );

--- a/src/rules/roles-creation.js
+++ b/src/rules/roles-creation.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function setRolesToUser(user, context, callback) {
 
   // Roles should only be set to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/saml-attribute-mapping.js
+++ b/src/rules/saml-attribute-mapping.js
@@ -11,7 +11,7 @@
  *
  */
 
-function (user, context, callback) {
+function mapSamlAttributes(user, context, callback) {
   context.samlConfiguration.mappings = {
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "user_id",
      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress":   "email",

--- a/src/rules/saml-configuration.js
+++ b/src/rules/saml-configuration.js
@@ -11,7 +11,7 @@
  *
  */
 
-function (user, context, callback) {
+function changeSamlConfiguration(user, context, callback) {
   if (context.clientID !== '{YOUR_SAMLP_OR_WSFED_CLIENT_ID}') return callback(null, user, context);
 
   context.samlConfiguration = context.samlConfiguration || {};

--- a/src/rules/send-events-keenio.js
+++ b/src/rules/send-events-keenio.js
@@ -15,7 +15,7 @@
  *
  */
 
-function(user, context, callback) {
+function sendEventsToKeen(user, context, callback) {
   if (context.stats.loginsCount > 1) {
     return callback(null, user, context);
   }

--- a/src/rules/send-events-segmentio.js
+++ b/src/rules/send-events-segmentio.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function sendEventsToSegmentIo(user, context, callback) {
   if (context.protocol === 'delegation') {
     return callback(null, user, context);
   }

--- a/src/rules/sendgrid.js
+++ b/src/rules/sendgrid.js
@@ -11,7 +11,7 @@
  * In the same way you can use other services like [Amazon SES](http://docs.aws.amazon.com/ses/latest/APIReference/Welcome.html), [Mandrill](https://auth0.com/mandrill) and few others.
  */
 
-function (user, context, callback) {
+function sendEmailWithSendgrid(user, context, callback) {
   user.app_metadata = user.app_metadata || {};
 
   if (user.app_metadata.signedUp) {

--- a/src/rules/simple-domain-whitelist.js
+++ b/src/rules/simple-domain-whitelist.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function emailDomainWhitelist(user, context, callback) {
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/simple-user-whitelist-for-app.js
+++ b/src/rules/simple-user-whitelist-for-app.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function userWhitelistForSpecificApp(user, context, callback) {
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/simple-user-whitelist.js
+++ b/src/rules/simple-user-whitelist.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function userWhitelist(user, context, callback) {
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/simple-whitelist-on-a-connection.js
+++ b/src/rules/simple-whitelist-on-a-connection.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function whitelistForSpecificConnection(user, context, callback) {
 
   // Access should only be granted to verified users.
   if (!user.email || !user.email_verified) {

--- a/src/rules/slack.js
+++ b/src/rules/slack.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function slackNotificationOnUserSignup(user, context, callback) {
   // short-circuit if the user signed up already or is using a refresh token
   if (context.stats.loginsCount > 1 || context.protocol === 'oauth2-refresh-token') {
     return callback(null, user, context);

--- a/src/rules/soap-webservice.js
+++ b/src/rules/soap-webservice.js
@@ -8,7 +8,7 @@
  *
  */
 
-function (user, context, callback) {
+function getRolesFromSoapService(user, context, callback) {
   const request = require('request');
   const xmldom = require('xmldom');
   const xpath = require('xpath');

--- a/src/rules/socure-fraudscore.js
+++ b/src/rules/socure-fraudscore.js
@@ -9,7 +9,7 @@
  *
  */
 
-function (user, context, callback) {
+function getSocureFraudScore(user, context, callback) {
   // score fraudscore once (if it's already set, skip this)
   user.app_metadata = user.app_metadata || {};
   if (user.app_metadata.socure_fraudscore) return callback(null, user, context);

--- a/src/rules/splunk-HEC-track-event.js
+++ b/src/rules/splunk-HEC-track-event.js
@@ -19,7 +19,7 @@
  *
  */
 
-function (user, context, callback) {
+function trackEventsWithSplunkHec(user, context, callback) {
   const request = require('request');
 
   user.app_metadata = user.app_metadata || {};

--- a/src/rules/update-firebase-user.js
+++ b/src/rules/update-firebase-user.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function updateFirebaseUser(user, context, callback) {
   const request = require('request');
 
   const baseURL = configuration.FIREBASE_URL;

--- a/src/rules/verify-user-email-with-password-reset.js
+++ b/src/rules/verify-user-email-with-password-reset.js
@@ -7,7 +7,7 @@
  *
  */
 
-function (user, context, callback) {
+function verifyUserWithPasswordReset(user, context, callback) {
   const request = require('request');
   const userApiUrl = auth0.baseUrl + '/users/';
 

--- a/src/rules/zapier-new-login.js
+++ b/src/rules/zapier-new-login.js
@@ -13,6 +13,7 @@
  */
 
 function triggerZapOnUserLogin(user, context, callback) {
+  const _ = require('lodash');
   const request = require('request');
 
   const small_context = {

--- a/src/rules/zapier-new-login.js
+++ b/src/rules/zapier-new-login.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function triggerZapOnUserLogin(user, context, callback) {
   const request = require('request');
 
   const small_context = {

--- a/src/rules/zapier-new-user.js
+++ b/src/rules/zapier-new-user.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function triggerZapOnNewUser(user, context, callback) {
   // short-circuit if the user signed up already
   if (context.stats.loginsCount > 1) {
     return callback(null, user, context);

--- a/src/rules/zapier-new-user.js
+++ b/src/rules/zapier-new-user.js
@@ -18,6 +18,7 @@ function triggerZapOnNewUser(user, context, callback) {
     return callback(null, user, context);
   }
 
+  const _ = require('lodash');
   const request = require('request');
 
   const small_context = {

--- a/src/rules/zendesk-sso-jwt.js
+++ b/src/rules/zendesk-sso-jwt.js
@@ -12,7 +12,7 @@
  *
  */
 
-function (user, context, callback) {
+function zendeskSsoWithJwt(user, context, callback) {
   const jwt = require('jsonwebtoken');
   const uuid = require('uuid');
 

--- a/test/rules/aspnet-webapi.test.js
+++ b/test/rules/aspnet-webapi.test.js
@@ -10,18 +10,12 @@ describe(ruleName, () => {
   let context;
   let user;
   let globals;
+  let request;
 
   const expectedCustomId = 'testId';
 
   beforeEach(() => {
     globals = {
-      request: {
-        post: jest
-          .fn()
-          .mockImplementation((url, cb) => {
-            cb(null, null, { customId: expectedCustomId })
-          })
-      },
       auth0: {
         users: {
           updateAppMetadata: jest.fn()
@@ -32,20 +26,28 @@ describe(ruleName, () => {
       }
     };
 
+    request = {
+      post: jest
+        .fn()
+        .mockImplementation((url, cb) => {
+          cb(null, null, { customId: expectedCustomId });
+        })
+    };
+
     user = new UserBuilder()
       .build();
 
     context = new ContextBuilder()
       .build();
 
-    rule = loadRule(ruleName, globals);
+    rule = loadRule(ruleName, globals, { request });
   });
 
   describe('when aspnet post request is successful', () => {
     it('should update the user metadata and set idToken', (done) => {
       const updateAppMetadataMock = globals.auth0.users.updateAppMetadata;
       updateAppMetadataMock.mockReturnValue(Promise.resolve());
-      
+
       rule(user, context, (e, u, c) => {
         const call = updateAppMetadataMock.mock.calls[0];
         expect(call[0]).toBe(user.user_id);

--- a/test/rules/dropbox-whitelist.test.js
+++ b/test/rules/dropbox-whitelist.test.js
@@ -10,22 +10,24 @@ describe(ruleName, () => {
   let context;
   let user;
   let globals;
+  let request;
 
   beforeEach(() => {
     globals = {
       UnauthorizedError: function() {},
-      request: {
-        get: jest
-          .fn()
-          .mockImplementation((opt, cb) => {
-            cb(null, { statusCode: 200 }, dropboxUsersFileFixture);
-          })
-      }
+    };
+
+    request = {
+      get: jest
+        .fn()
+        .mockImplementation((opt, cb) => {
+          cb(null, { statusCode: 200 }, dropboxUsersFileFixture);
+        })
     };
 
     context = new ContextBuilder().build();
 
-    rule = loadRule(ruleName, globals);
+    rule = loadRule(ruleName, globals, { request });
   });
 
   describe('when the rule is executed', () => {

--- a/test/rules/get-fullcontact-profile.test.js
+++ b/test/rules/get-fullcontact-profile.test.js
@@ -5,6 +5,7 @@ const ContextBuilder = require('../utils/contextBuilder');
 const UserBuilder = require('../utils/userBuilder');
 
 const ruleName = 'get-fullcontact-profile';
+
 describe(ruleName, () => {
   let rule;
   let context;
@@ -14,13 +15,6 @@ describe(ruleName, () => {
 
   beforeEach(() => {
     globals = {
-      request: {
-        get: jest
-          .fn()
-          .mockImplementationOnce((url, obj, cb) => {
-            cb(null, { statusCode: 200 }, fullContactData)
-          })
-      },
       auth0: {
         users: {
           updateUserMetadata: jest.fn()
@@ -31,7 +25,16 @@ describe(ruleName, () => {
         SLACK_HOOK_URL: 'YOUR SLACK HOOK URL'
       }
     };
-    stubs['slack-notify'] = jest.fn()
+
+    stubs['slack-notify'] = jest.fn();
+
+    stubs.request = {
+      get: jest
+        .fn()
+        .mockImplementationOnce((url, obj, cb) => {
+          cb(null, { statusCode: 200 }, fullContactData);
+        })
+    };
 
     user = new UserBuilder().build();
 

--- a/test/rules/get-towerdata-profile.test.js
+++ b/test/rules/get-towerdata-profile.test.js
@@ -10,26 +10,28 @@ describe(ruleName, () => {
   let context;
   let user;
   let globals;
+  let request;
 
   beforeEach(() => {
     globals = {
       global: {},
-      request: {
-        get: jest
-          .fn()
-          .mockImplementationOnce((url, obj, cb) => {
-            cb(null, { statusCode: 200 }, towerdataBody)
-          })
-      },
       configuration: {
         TOWERDATA_API_KEY: 'YOUR towerdata API KEY'
       }
     };
 
+    request = {
+      get: jest
+        .fn()
+        .mockImplementationOnce((url, obj, cb) => {
+          cb(null, { statusCode: 200 }, towerdataBody);
+        })
+    };
+
     user = new UserBuilder().build();
     context = new ContextBuilder().build();
 
-    rule = loadRule(ruleName, globals);
+    rule = loadRule(ruleName, globals, { request });
   });
 
   describe('when the rule is executed', () => {

--- a/test/rules/get-twitter-email.test.js
+++ b/test/rules/get-twitter-email.test.js
@@ -5,6 +5,11 @@ const RequestBuilder = require('../utils/requestBuilder');
 const UserBuilder = require('../utils/userBuilder');
 
 const ruleName = 'get-twitter-email';
+
+const twitterDataSample = {
+  email: 'some@email.test'
+};
+
 describe(ruleName, () => {
   let rule;
   let context;
@@ -14,18 +19,10 @@ describe(ruleName, () => {
 
   beforeEach(() => {
     globals = {
-      request: {
-        get: jest
-          .fn()
-          .mockImplementationOnce((url, obj, cb) => {
-            cb(null, { statusCode: 200 }, twitterDataSample)
-          })
-      },
       configuration: {
         TWITTER_CONSUMER_KEY: 'UPDATE-WITH-YOUR-CONSUMER-KEY',
         TWITTER_CONSUMER_SECRET_KEY: 'UPDATE-WITH-YOUR-CONSUMER-SECRET-KEY'
       },
-      _: require('lodash')
     };
 
     user = new UserBuilder()
@@ -42,10 +39,18 @@ describe(ruleName, () => {
       .withConnectionStrategy('twitter')
       .build();
 
+    stubs['request'] = {
+      get: jest.fn()
+        .mockImplementationOnce((url, obj, cb) => {
+          cb(null, { statusCode: 200 }, twitterDataSample);
+        })
+    };
+
     stubs['oauth-sign'] = {
       hmacsign: jest.fn(() => 'oauth sig'),
       rfc3986: jest.fn(() => 'rfc val')
     };
+
     stubs['uuid'] = {
       v4: jest.fn(() => 'cfef96ed-3198-44ee-b7fd-64caeaca7b76')
     };
@@ -61,7 +66,3 @@ describe(ruleName, () => {
     });
   });
 });
-
-const twitterDataSample = {
-  email: 'some@email.test'
-}

--- a/test/rules/mixpanel-track-event.test.js
+++ b/test/rules/mixpanel-track-event.test.js
@@ -15,13 +15,12 @@ describe(ruleName, () => {
     };
 
     const globals = {
-      request,
       configuration: {
         MIXPANEL_API_TOKEN: '{REPLACE_WITH_YOUR_MIXPANEL_TOKEN}'
       }
     };
 
-    rule = loadRule(ruleName, globals);
+    rule = loadRule(ruleName, globals, { request });
   });
 
   it('should send mixpanel request', (done) => {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR intends to remove all magic globals references from all rules templates. The `auth0`, `configuration`, and custom errors will still be used as they were previously.

### References

https://auth0team.atlassian.net/browse/DXEX-458

### Testing

I manually tested that the new Mongo and SQL Server scripts work on Node 8. All of the others were trivial changes. 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
