### PR TITLE
Sample rules using the Auth0 Signals API

### DIFF
--- a/src/rules/signals-email-confidence-score.js
+++ b/src/rules/signals-email-confidence-score.js
@@ -11,6 +11,13 @@
  * > Note: You should sign up first in Auth0 Signals (https://auth0.com/signals)
  * and copy the API Key given into a setting key named AUTH0SIGNALS_API_KEY.
  *
+ * DISCLAIMER: Auth0 Signals is free for all and offered 'as is': there is no SLA 
+ * for the service and the maximum number of daily requests is 40000
+ * (https://community.auth0.com/t/how-to-obtain-an-auth0-signals-api-key/42048).
+ * You can read the latest full Terms of Service here: 
+ * (https://auth0.com/signals/terms-of-service)
+ *
+ * 
  */
 function getBadEmailDetection(user, context, callback) {
 
@@ -29,10 +36,17 @@ function getBadEmailDetection(user, context, callback) {
       },
       headers: {
         'content-type': 'application/json'
-      }
+      },
+      timeout: 1000
     }, function (err, resp, body) {
-      if (err) return callback(null, user, context);
-      if (resp.statusCode !== 200) return callback(null, user, context);
+      if (err) {
+        console.log('Error request to Signals:' + err.code + ', ' + err);
+        return callback(null, user, context);
+      }
+      if (resp.statusCode !== 200) {
+        console.log('Signals not returning 200:' + resp.statusCode);
+        return callback(null, user, context);
+      }
       const signals_response = JSON.parse(body);
   
       user.user_metadata.email = user.user_metadata.email || {};
@@ -44,7 +58,6 @@ function getBadEmailDetection(user, context, callback) {
       auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
         .then(function(){
             context.idToken['https://example.com/email'] = user.user_metadata.email;
-            console.log(user);
             callback(null, user, context);
         })
         .catch(function(err){

--- a/src/rules/signals-email-confidence-score.js
+++ b/src/rules/signals-email-confidence-score.js
@@ -1,0 +1,55 @@
+/**
+ * @title Detect if the email address of the user has a poor confidence score
+ * @overview Look up in Auth0 Email Signals (https://auth0.com/signals) and store the score in the user's metadata.
+ * @gallery true
+ * @category access control
+ *
+ * This rule query to the Auth0 Email Signals API about the email of the user 
+ * and running a confidence score algorithm. The result is stored in the 
+ * user's metadata for further analysis.
+ * 
+ * > Note: You should sign up first in Auth0 Signals (https://auth0.com/signals)
+ * and copy the API Key given into a setting key named AUTH0SIGNALS_API_KEY.
+ *
+ */
+function getBadEmailDetection(user, context, callback) {
+
+    // skip if no email
+    if (!user.email) return callback(null, user, context);
+  
+    user.user_metadata = user.user_metadata || {};
+  
+    const request = require('request');
+    
+    console.log('Preparing request to Auth0-Signals');
+    request({
+      url: 'https://signals.api.auth0.com/bademail/' + user.email + '?timeout=0',
+      qs: {
+        token:  configuration.AUTH0SIGNALS_API_KEY
+      },
+      headers: {
+        'content-type': 'application/json'
+      }
+    }, function (err, resp, body) {
+      if (err) return callback(null, user, context);
+      if (resp.statusCode !== 200) return callback(null, user, context);
+      const signals_response = JSON.parse(body);
+  
+      user.user_metadata.email = user.user_metadata.email || {};
+  
+      // the full JSON object returned can be found here: https://auth0.com/signals/docs/#email
+      user.user_metadata.email = signals_response.response;
+    
+      // persist the user_metadata update
+      auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+        .then(function(){
+            context.idToken['https://example.com/email'] = user.user_metadata.email;
+            console.log(user);
+            callback(null, user, context);
+        })
+        .catch(function(err){
+            console.log(err);
+            callback(err);
+        });
+    });
+  }

--- a/src/rules/signals-ip-blacklisted.js
+++ b/src/rules/signals-ip-blacklisted.js
@@ -1,0 +1,56 @@
+/**
+ * @title Detect if IP address is in a blacklist
+ * @overview Look up in Auth0 IP Signals (https://auth0.com/signals/ip) and add the name of the blacklist to the user's metadata.
+ * @gallery true
+ * @category access control
+ *
+ * This rule query to the Auth0 IP Signals API about the IP address the user 
+ * connects from, whether it is blacklisted or not. If so, it will store the
+ * blacklists names on user_metadata.
+ * 
+ * > Note: You should sign up first in Auth0 Signals (https://auth0.com/signals)
+ * and copy the API Key given into a setting key named AUTH0SIGNALS_API_KEY.
+ *
+ */
+function getBadIPAddressDetection(user, context, callback) {
+    user.user_metadata = user.user_metadata || {};
+  
+    const request = require('request');
+    
+    console.log('Preparing request to Auth0-Signals');
+    request({
+      url: 'https://signals.api.auth0.com/badip/' + context.request.ip,
+      qs: {
+        token:  configuration.AUTH0SIGNALS_API_KEY
+      },
+      headers: {
+        'content-type': 'application/json'
+      }
+    }, function (err, resp, body) {
+      if (err) return callback(null, user, context);
+      if ((resp.statusCode !== 200) && (resp.statusCode !== 404)) return callback(null, user, context);
+      let signals_response = {'response':[]};
+      if (resp.statusCode === 200) {
+        signals_response = JSON.parse(body);
+      }
+  
+      if (typeof user.user_metadata.source_ip === 'undefined') {
+          user.user_metadata.source_ip = {};
+      }
+  
+      user.user_metadata.source_ip.blacklists = signals_response.response;
+      user.user_metadata.source_ip.ip = context.request.ip;
+    
+      // persist the user_metadata update
+      auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+        .then(function(){
+            context.idToken['https://example.com/blacklists'] = user.user_metadata.source_ip.blacklists;
+            console.log(user);
+            callback(null, user, context);
+        })
+        .catch(function(err){
+            console.log(err);
+            callback(err);
+        });
+    });
+  }

--- a/src/rules/signals-ip-info.js
+++ b/src/rules/signals-ip-info.js
@@ -1,0 +1,78 @@
+/**
+ * @title Find the network provider, country and continent of the IP address
+ * @overview Get information about the geolocation and network provider (ASN) with Auth0 IP Signals (https://auth0.com/signals/ip) and add the result to the user's metadata.
+ * @gallery true
+ * @category enrich profile
+ *
+ * This rule query to the Auth0 IP Signals API about the geolocation and network
+ * provider extracted from the IP address of the user. The result is stored on 
+ * the user_metadata.
+ * 
+ * > Note: You should sign up first in Auth0 Signals (https://auth0.com/signals)
+ * and copy the API Key given into a setting key named AUTH0SIGNALS_API_KEY.
+ *
+ */
+function getBadIPAddressDetection(user, context, callback) {
+    user.user_metadata = user.user_metadata || {};
+  
+    const request = require('request');
+    
+    console.log('Preparing request to Auth0-Signals');
+    request({
+      url: 'https://signals.api.auth0.com/geoip/' + context.request.ip,
+      qs: {
+        token:  configuration.AUTH0SIGNALS_API_KEY
+      },
+      headers: {
+        'content-type': 'application/json'
+      }
+    }, function (err, resp, body) {
+      if (err) return callback(null, user, context);
+      if (resp.statusCode !== 200) return callback(null, user, context);
+      const signals_response = JSON.parse(body);
+  
+  //    "source_ip": {
+  //      "country_code": "",
+  //      "continent_code": "",
+  //      "asn": "",
+  //      "ip": "",
+  //      "asn_name": ""
+  //    },
+      if (typeof user.user_metadata.source_ip === 'undefined') {
+        user.user_metadata.source_ip = {};
+      }
+  
+      if (typeof signals_response.ip.country !== 'undefined') {
+        user.user_metadata.source_ip.country_code = signals_response.ip.country;
+        user.user_metadata.source_ip.continent_code = signals_response.ip.continent;  
+      }
+      else {
+        user.user_metadata.source_ip.country_code = '';
+        user.user_metadata.source_ip.continent_code = '';  
+      }
+  
+      if (typeof signals_response.ip.as.asn !== 'undefined') {
+        user.user_metadata.source_ip.asn = signals_response.ip.as.asn;
+        user.user_metadata.source_ip.asn_name = signals_response.ip.as.name;
+      }
+      else {
+        user.user_metadata.source_ip.asn = '';
+        user.user_metadata.source_ip.asn_name = '';
+      }
+    
+      // persist the user_metadata update
+      auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+        .then(function(){
+            context.idToken['https://example.com/country_code'] = user.user_metadata.source_ip.country_code;
+            context.idToken['https://example.com/continent_code'] = user.user_metadata.source_ip.continent_code;
+            context.idToken['https://example.com/asn'] = user.user_metadata.source_ip.asn;
+            context.idToken['https://example.com/asn_name'] = user.user_metadata.source_ip.asn_name;
+            console.log(user);
+            callback(null, user, context);
+        })
+        .catch(function(err){
+            console.log(err);
+            callback(err);
+        });
+    });
+  }

--- a/test/rules/signals-email-confidence-score.test.js
+++ b/test/rules/signals-email-confidence-score.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const nock = require('nock');
+
+const loadRule = require('../utils/load-rule');
+const ContextBuilder = require('../utils/contextBuilder');
+const RequestBuilder = require('../utils/requestBuilder');
+const UserBuilder = require('../utils/userBuilder');
+
+const ruleName = 'signals-email-confidence-score';
+
+const responseJson = {
+  'response':{
+     'email':{
+        'blacklist':[
+           'TEST-EMAIL'
+        ],
+        'score':-1
+     },
+     'domain':{
+        'blacklist':[
+           'TEST-DOMAIN'
+        ],
+        'blacklist_mx':[
+
+        ],
+        'blacklist_ns':[
+
+        ],
+        'mx':[
+           'mx.test.com'
+        ],
+        'ns':[
+           'ns.test.com'
+        ],
+        'score':-1
+     },
+     'disposable':{
+        'is_disposable':false,
+        'score':0
+     },
+     'freemail':{
+        'is_freemail':true,
+        'score':0
+     },
+     'ip':{
+        'blacklist':[
+           'TEST-IP'
+        ],
+        'is_quarantined':false,
+        'address':'1.2.3.4',
+        'score':-1
+     },
+     'source_ip':{
+        'blacklist':[],
+        'is_quarantined':false,
+        'address':'88.3.83.46',
+        'score':0
+     },
+     'address':{
+        'is_role':false,
+        'is_well_formed':true,
+        'score':0
+     },
+     'smtp':{
+        'exist_mx':true,
+        'exist_address':true,
+        'exist_catchall':false,
+        'graylisted':false,
+        'timedout':false,
+        'score':0
+     },
+     'score':-3,
+     'email_address':'test@example.com'
+  },
+  'type':'bademail'
+};
+
+describe(ruleName, () => {
+  let context;
+  let rule;
+  let rule_clean;
+  let user;
+
+  const configuration = {
+    AUTH0SIGNALS_API_KEY: 'YOUR_AUTH0SIGNALS_API_KEY'
+  };
+
+  const auth0 = {
+    users: {
+      updateUserMetadata: (id, metadata) => {
+        if (id === 'broken') {
+          return Promise.reject();
+        }
+        
+        expect(id).toEqual('12345');
+        return Promise.resolve();
+      }
+    }
+  };
+
+  beforeEach(() => {
+    rule = loadRule(ruleName, { configuration, auth0 });
+    rule_clean = loadRule(ruleName, { configuration });
+
+    const request = new RequestBuilder().build();
+    context = new ContextBuilder()
+      .withRequest(request)
+      .build();
+    user = new UserBuilder()
+      .build();
+    });
+
+  it('should get email reputation score from Signals and add it to idToken and user metadata', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/bademail/superuser@users.com?timeout=0&token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(200, responseJson);
+
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c.idToken['https://example.com/email']['email_address']).toEqual(responseJson.response.email_address);
+      expect(c.idToken['https://example.com/email']['score']).toEqual(responseJson.response.score);
+      expect(c.idToken['https://example.com/email']['email']['blacklist']).toEqual(responseJson.response.email.blacklist);
+      expect(c.idToken['https://example.com/email']['email']['score']).toEqual(responseJson.response.email.score);
+      expect(c.idToken['https://example.com/email']['domain']['blacklist']).toEqual(responseJson.response.domain.blacklist);
+      expect(c.idToken['https://example.com/email']['domain']['blacklist_mx']).toEqual(responseJson.response.domain.blacklist_mx);
+      expect(c.idToken['https://example.com/email']['domain']['blacklist_ns']).toEqual(responseJson.response.domain.blacklist_ns);
+      expect(c.idToken['https://example.com/email']['domain']['score']).toEqual(responseJson.response.domain.score);
+      expect(c.idToken['https://example.com/email']['ip']['blacklist']).toEqual(responseJson.response.ip.blacklist);
+      expect(c.idToken['https://example.com/email']['ip']['score']).toEqual(responseJson.response.ip.score);
+      expect(c.idToken['https://example.com/email']['disposable']['is_disposable']).toEqual(responseJson.response.disposable.is_disposable);
+      expect(c.idToken['https://example.com/email']['freemail']['is_freemail']).toEqual(responseJson.response.freemail.is_freemail);
+      expect(c.idToken['https://example.com/email']['smtp']['score']).toEqual(responseJson.response.smtp.score);
+      expect(c.idToken['https://example.com/email']['address']['score']).toEqual(responseJson.response.address.score);
+
+      expect(u.user_metadata.email['email_address']).toEqual(responseJson.response.email_address);
+      expect(u.user_metadata.email['score']).toEqual(responseJson.response.score);
+      expect(u.user_metadata.email['email']['blacklist']).toEqual(responseJson.response.email.blacklist);
+      expect(u.user_metadata.email['email']['score']).toEqual(responseJson.response.email.score);
+      expect(u.user_metadata.email['domain']['blacklist']).toEqual(responseJson.response.domain.blacklist);
+      expect(u.user_metadata.email['domain']['blacklist_mx']).toEqual(responseJson.response.domain.blacklist_mx);
+      expect(u.user_metadata.email['domain']['blacklist_ns']).toEqual(responseJson.response.domain.blacklist_ns);
+      expect(u.user_metadata.email['domain']['score']).toEqual(responseJson.response.domain.score);
+      expect(u.user_metadata.email['ip']['blacklist']).toEqual(responseJson.response.ip.blacklist);
+      expect(u.user_metadata.email['ip']['score']).toEqual(responseJson.response.ip.score);
+      expect(u.user_metadata.email['disposable']['is_disposable']).toEqual(responseJson.response.disposable.is_disposable);
+      expect(u.user_metadata.email['freemail']['is_freemail']).toEqual(responseJson.response.freemail.is_freemail);
+      expect(u.user_metadata.email['smtp']['score']).toEqual(responseJson.response.smtp.score);
+      expect(u.user_metadata.email['address']['score']).toEqual(responseJson.response.address.score);
+
+      done();
+    });
+  });
+
+  it('should get empty email reputation data from Signals when returning 429', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/bademail/superuser@users.com?timeout=0&token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(429);
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      expect(c.idToken['https://example.com/email']).toEqual(undefined);
+      done();
+    });
+  });
+
+  it('should do nothing if request fails', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json',
+      },    
+    })
+      .get('/bademail/superuser@users.com?timeout=0&token=YOUR_AUTH0SIGNALS_API_KEY')
+      .replyWithError(new Error('test error'));
+
+    rule({}, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      expect(c.idToken['https://example.com/email']).toEqual(undefined);
+      done();
+    });
+  });
+});

--- a/test/rules/signals-ip-blacklisted.test.js
+++ b/test/rules/signals-ip-blacklisted.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const nock = require('nock');
+
+const loadRule = require('../utils/load-rule');
+const ContextBuilder = require('../utils/contextBuilder');
+const RequestBuilder = require('../utils/requestBuilder');
+const UserBuilder = require('../utils/userBuilder');
+
+const ruleName = 'signals-ip-blacklisted';
+
+describe(ruleName, () => {
+  let context;
+  let rule;
+  let rule_clean;
+  let user;
+
+  const configuration = {
+    AUTH0SIGNALS_API_KEY: 'YOUR_AUTH0SIGNALS_API_KEY'
+  };
+
+  const auth0 = {
+    users: {
+      updateUserMetadata: (id, metadata) => {
+        if (id === 'broken') {
+          return Promise.reject();
+        }
+        
+        expect(id).toEqual('12345');
+        expect(metadata.source_ip.ip).toEqual('188.6.125.49');
+        return Promise.resolve();
+      }
+    }
+  };
+
+  beforeEach(() => {
+    rule = loadRule(ruleName, { configuration, auth0 });
+    rule_clean = loadRule(ruleName, { configuration });
+
+    const request = new RequestBuilder().build();
+    context = new ContextBuilder()
+      .withRequest(request)
+      .build();
+    user = new UserBuilder()
+      .build();
+    });
+
+  it('should get data found from Signals and add it to idToken and user metadata', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/badip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(200, {response: ['STOPFORUMSPAM-1']});
+
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c.idToken['https://example.com/blacklists']).toEqual(['STOPFORUMSPAM-1']);
+      expect(u.user_metadata.source_ip.blacklists).toEqual(['STOPFORUMSPAM-1']);
+      expect(u.user_metadata.source_ip.ip).toEqual('188.6.125.49');
+      done();
+    });
+  });
+
+  it('should get data not found from Signals and add it to idToken and user metadata', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/badip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(404);
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c.idToken['https://example.com/blacklists']).toEqual([]);
+      expect(u.user_metadata.source_ip.blacklists).toEqual([]);
+      expect(u.user_metadata.source_ip.ip).toEqual('188.6.125.49');
+      done();
+    });
+  });
+
+  it('should do nothing if request fails', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json',
+      },    
+    })
+      .get('/badip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .replyWithError(new Error('test error'));
+
+    rule({}, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      done();
+    });
+  });
+
+  it('should get data not found from Signals when returning 429', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/badip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(429);
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      expect(u).toEqual(user);
+      expect(c.idToken['https://example.com/blacklists']).toEqual(undefined);
+      done();
+    });
+  });
+
+  it('should get data not found from Signals when returning 400', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/badip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(400);
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      expect(u).toEqual(user);
+      expect(c.idToken['https://example.com/blacklists']).toEqual(undefined);
+      done();
+    });
+  });
+
+});

--- a/test/rules/signals-ip-info.test.js
+++ b/test/rules/signals-ip-info.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const nock = require('nock');
+
+const loadRule = require('../utils/load-rule');
+const ContextBuilder = require('../utils/contextBuilder');
+const RequestBuilder = require('../utils/requestBuilder');
+const UserBuilder = require('../utils/userBuilder');
+
+const ruleName = 'signals-ip-info';
+
+const responseJson = {
+  'ip':{
+     'address':'188.6.125.49',
+     'hostname':'',
+     'country':'HU',
+     'country_names':{
+     },
+     'country_geoname_id':719819,
+     'continent':'EU',
+     'continent_names':{
+     },
+     'continent_geoname_id':6255148,
+     'latitude':0,
+     'longitude':0,
+     'time_zone':'Europe/Budapest',
+     'region':'Budapest',
+     'region_names':{
+     },
+     'region_geoname_id':3054638,
+     'city':'Budapest',
+     'city_names':{
+     },
+     'city_geoname_id':3054643,
+     'accuracy_radius':20,
+     'postal':'',
+     'as':{
+        'name':'Magyar Telekom plc.',
+        'country':'HU',
+        'networks':[
+        ],
+        'asn':'5483'
+     }
+  }
+};
+
+describe(ruleName, () => {
+  let context;
+  let rule;
+  let rule_clean;
+  let user;
+
+  const configuration = {
+    AUTH0SIGNALS_API_KEY: 'YOUR_AUTH0SIGNALS_API_KEY'
+  };
+
+  const auth0 = {
+    users: {
+      updateUserMetadata: (id, metadata) => {
+        if (id === 'broken') {
+          return Promise.reject();
+        }
+        
+        expect(id).toEqual('12345');
+        return Promise.resolve();
+      }
+    }
+  };
+
+  beforeEach(() => {
+    rule = loadRule(ruleName, { configuration, auth0 });
+    rule_clean = loadRule(ruleName, { configuration });
+
+    const request = new RequestBuilder().build();
+    context = new ContextBuilder()
+      .withRequest(request)
+      .build();
+    user = new UserBuilder()
+      .build();
+    });
+
+  it('should get geo data from Signals and add it to idToken and user metadata', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/geoip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(200, responseJson);
+
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c.idToken['https://example.com/country_code']).toEqual(responseJson.ip.country);
+      expect(c.idToken['https://example.com/continent_code']).toEqual(responseJson.ip.continent);
+      expect(c.idToken['https://example.com/asn']).toEqual(responseJson.ip.as.asn);
+      expect(c.idToken['https://example.com/asn_name']).toEqual(responseJson.ip.as.name);
+      expect(u.user_metadata.source_ip.country_code).toEqual(responseJson.ip.country);
+      expect(u.user_metadata.source_ip.continent_code).toEqual(responseJson.ip.continent);
+      expect(u.user_metadata.source_ip.asn).toEqual(responseJson.ip.as.asn);
+      expect(u.user_metadata.source_ip.asn_name).toEqual(responseJson.ip.as.name);
+      done();
+    });
+  });
+
+  it('should get empty geo data from Signals and add it to idToken and user metadata', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/geoip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(200, {ip:{}});
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c.idToken['https://example.com/country_code']).toEqual('');
+      expect(c.idToken['https://example.com/continent_code']).toEqual('');
+      expect(c.idToken['https://example.com/asn']).toEqual('');
+      expect(c.idToken['https://example.com/asn_name']).toEqual('');
+      expect(u.user_metadata.source_ip.country_code).toEqual('');
+      expect(u.user_metadata.source_ip.continent_code).toEqual('');
+      expect(u.user_metadata.source_ip.asn).toEqual('');
+      expect(u.user_metadata.source_ip.asn_name).toEqual('');
+      done();
+    });
+  });
+
+  it('should do nothing if request fails', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json',
+      },    
+    })
+      .get('/geoip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .replyWithError(new Error('test error'));
+
+    rule({}, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      done();
+    });
+  });
+
+  it('should get empty empty geo data from Signals when returning 429', (done) => {
+    nock('https://signals.api.auth0.com', {
+      reqheaders: {
+        'content-type': 'application/json'
+      },    
+    })
+      .get('/geoip/188.6.125.49?token=YOUR_AUTH0SIGNALS_API_KEY')
+      .reply(429);
+    rule(user, context, (err, u, c) => {
+      expect(err).toBeFalsy();
+      expect(c).toEqual(context);
+      expect(c.idToken['https://example.com/country_code']).toEqual(undefined);
+      expect(c.idToken['https://example.com/continent_code']).toEqual(undefined);
+      expect(c.idToken['https://example.com/asn']).toEqual(undefined);
+      expect(c.idToken['https://example.com/asn_name']).toEqual(undefined);
+      done();
+    });
+  });
+  
+});
+


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR contains three different samples about how to enrich
a user's profile or use this information for access control:
- signals-ip-info.js: enrich user_metadata with information about
the country, continent, network provider name and ASN of the IP
address of the client.
- signals-ip-blacklisted.js: enrich the user_metadata with any
existing blacklists where Auth0 Signals found the IP address of
 the client.
- signals-email-confidence-score.js: enrich the user_metadata with
the confidence score obtained from querying Auth0 Signals about
the email address of the user.

All the examples need a setting key named AUTH0SIGNALS_API_KEY.
This setting should contain the API Key obtained after signing up
in Auth0 Signals (https://auth0.com/signals).


### References

https://auth0.com/signals

### Testing

Adding these rules should create on user_metadata new entries related with the information obtained from the Auth0 Signals API.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
