### PR TITLE
Track Consent Rule - add commented ability to set version of consent given

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -336,7 +336,7 @@
           "enrich profile"
         ],
         "description": "<p>This rule will add two attributes to the user's metadata object on when they accepted the terms and conditions.</p>\n<p>This is useful for cases where you want to track an user's consent. See https://auth0.com/docs/compliance/gdpr/features-aiding-compliance/user-consent/track-consent-with-lock for more information.</p>",
-        "code": "function (user, context, callback) {\n    user.user_metadata = user.user_metadata || {};\n    // short-circuit if the user signed up already\n    if (user.user_metadata.consentGiven) return callback(null, user, context);\n    \n    // first time login/signup\n    user.user_metadata.consentGiven = true;\n    user.user_metadata.consentTimestamp = Date.now();\n    auth0.users.updateUserMetadata(user.user_id, user.user_metadata)\n    .then(function(){\n      callback(null, user, context);\n    })\n    .catch(function(err){\n      callback(err);\n    });\n  }"
+        "code": "function trackConsent(user, context, callback) {\n  user.user_metadata = user.user_metadata || {};\n  // short-circuit if the user signed up already\n  if (user.user_metadata.consentGiven) return callback(null, user, context);\n\n  // first time login/signup\n  user.user_metadata.consentGiven = true;\n  // uncomment to track consentVersion\n  // user.user_metadata.consentVersion = \"1.9\";\n\n  user.user_metadata.consentTimestamp = Date.now();\n  auth0.users.updateUserMetadata(user.user_id, user.user_metadata)\n    .then(function () {\n      callback(null, user, context);\n    })\n    .catch(function (err) {\n      callback(err);\n    });\n}"
       }
     ]
   },

--- a/src/rules/track-consent.js
+++ b/src/rules/track-consent.js
@@ -10,19 +10,22 @@
  *
  */
 
-function (user, context, callback) {
-    user.user_metadata = user.user_metadata || {};
-    // short-circuit if the user signed up already
-    if (user.user_metadata.consentGiven) return callback(null, user, context);
-    
-    // first time login/signup
-    user.user_metadata.consentGiven = true;
-    user.user_metadata.consentTimestamp = Date.now();
-    auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
-    .then(function(){
+function trackConsent(user, context, callback) {
+  user.user_metadata = user.user_metadata || {};
+  // short-circuit if the user signed up already
+  if (user.user_metadata.consentGiven) return callback(null, user, context);
+
+  // first time login/signup
+  user.user_metadata.consentGiven = true;
+  // uncomment to track consentVersion
+  // user.user_metadata.consentVersion = "1.9";
+
+  user.user_metadata.consentTimestamp = Date.now();
+  auth0.users.updateUserMetadata(user.user_id, user.user_metadata)
+    .then(function () {
       callback(null, user, context);
     })
-    .catch(function(err){
+    .catch(function (err) {
       callback(err);
     });
-  }
+}


### PR DESCRIPTION
### Description

Adds a commented User Metadata option to set consentVersion

### Testing

No new default capability added, so test coverage change is not needed. 
### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
