### PR TITLE
Fix onfido missing trailing semicolon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-templates",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Auth0 Rules Repository",
   "main": "./rules",
   "scripts": {

--- a/src/rules/onfido-idv.js
+++ b/src/rules/onfido-idv.js
@@ -49,7 +49,7 @@ async function onfidoIdentityVerification(user, context, callback) {
   });
 
   user.app_metadata = user.app_metadata || {};
-  user.app_metadata.onfido = user.app_metadata.onfido || {}
+  user.app_metadata.onfido = user.app_metadata.onfido || {};
 
   if (ruleUtils.isRedirectCallback && ruleUtils.queryParams.session_token && "true" === ruleUtils.queryParams.onfido_idv) {
     // User is back from the Onfido experience and has a session token to validate and assign to user meta


### PR DESCRIPTION
### Description

Missing semicolon is causing warning when saving the rule after creation.

### References

https://auth0.slack.com/archives/C013GKQR53K/p1600729720187800

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
