### PR TITLE
updating fullcontact endpoint

### DIFF
--- a/src/rules/get-fullcontact-profile.js
+++ b/src/rules/get-fullcontact-profile.js
@@ -27,13 +27,15 @@ function getFullContactProfile(user, context, callback) {
     return callback(null, user, context);
 
   request.get(
-    'https://api.fullcontact.com/v2/person.json',
+    'https://api.fullcontact.com/v3/person.enrich',
     {
-      qs: {
-        email: user.email,
-        apiKey: FULLCONTACT_KEY
+      body: {
+        email: user.email
       },
-      json: true
+      json: true,
+      headers: {
+        'Authorization': 'Bearer ' + FULLCONTACT_KEY
+      }
     },
     (error, response, body) => {
       if (error || (response && response.statusCode !== 200)) {


### PR DESCRIPTION
### Description

> The existing rules is sending the API Key in the querystring and resulting in a 401 HTTP status code.
> According to [FullContact's documentation](https://dashboard.fullcontact.com/api-ref#webhooks), the API key should now be sent in the header:
`curl -H "X-FullContact-APIKey:{Your API Key}" "https://api.fullcontact.com/v2/person.json?email=bart@fullcontact.com"`
> Since it needs to change, I took advantage of this and already updated it to version 3.
`curl -X POST https://api.fullcontact.com/v3/person.enrich \
-H "Authorization: Bearer {Your API Key}" \
-d '{"email":"bart@fullcontact.com"}'
`

### Testing

> Deploy the template rule and replace the FullContact API Key. In my test, I replaced SLACK hook to a console.log.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
