### PR TITLE
feat(incognia-onboarding.js): creating rule

### DIFF
--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -11,7 +11,7 @@ async function incogniaOnboardingRule(user, context, callback) {
   const { IncogniaAPI } = require('@incognia/api@1.0.0')
   const { Auth0UserUpdateUtilities } = require('@auth0/rule-utilities@0.2.0')
 
-  const { INCOGNIA_CLIENT_ID, INCOGNIA_CLIENT_SECRET } = configuration;
+  const { INCOGNIA_CLIENT_ID, INCOGNIA_CLIENT_SECRET, INCOGNIA_HOME_ADDRESS_PROP } = configuration;
 
   if (!INCOGNIA_CLIENT_ID || !INCOGNIA_CLIENT_SECRET) {
     console.log('Missing required configuration. Skipping.');
@@ -20,20 +20,24 @@ async function incogniaOnboardingRule(user, context, callback) {
 
   // For this rule to be used, please set 'incognia_onboarding_rule' as 'enabled' in your Auth0
   // application metadata. This can be done in the advanced settings of your app.
+  // https://auth0.com/docs/get-started/dashboard/application-settings#application-metadata
   const incogniaOnboardingRule = _.get(context, 'clientMetadata.incognia_onboarding_rule');
-  if (!incogniaOnboardingRule || incogniaOnboardingRule !== 'enabled') {
+  if (incogniaOnboardingRule !== 'enabled') {
     console.log('Incognia onboarding rule is not enabled for this client. Skipping');
     return callback(null, user, context);
   }
 
-  const installationId = _.get(context, 'request.query.installation_id');
+  const installationId = _.get(context, 'request.query.incognia_installation_id');
   if (!installationId) {
     console.log('Missing installation_id. Skipping.');
     return callback(null, user, context);
   }
 
-  // User home address should be set using Auth0's Signup API for example.
-  const homeAddress = _.get(user, 'user_metadata.home_address');
+  // User home address should be set using Auth0's Signup API for example. If the home address is
+  // not in 'user_metadata.home_address', please specify the path of the field inside the user
+  // object where the home address is through the INCOGNIA_HOME_ADDRESS_PROP configuration.
+  const homeAddressProp = INCOGNIA_HOME_ADDRESS_PROP || 'user_metadata.home_address';
+  const homeAddress = _.get(user, homeAddressProp);
   if (!homeAddress) {
     console.log('Missing user home address. Skipping.');
     return callback(null, user, context);

--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -18,15 +18,6 @@ async function incogniaOnboardingRule(user, context, callback) {
     return callback(null, user, context);
   }
 
-  // For this rule to be used, please set 'incognia_onboarding_rule' as 'enabled' in your Auth0
-  // application metadata. This can be done in the advanced settings of your app.
-  // https://auth0.com/docs/get-started/dashboard/application-settings#application-metadata
-  const incogniaOnboardingRule = _.get(context, 'clientMetadata.incognia_onboarding_rule');
-  if (incogniaOnboardingRule !== 'enabled') {
-    console.log('Incognia onboarding rule is not enabled for this client. Skipping');
-    return callback(null, user, context);
-  }
-
   const installationId = _.get(context, 'request.query.incognia_installation_id');
   if (!installationId) {
     console.log('Missing installation_id. Skipping.');

--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -6,10 +6,10 @@
  *
  */
 async function incogniaOnboardingRule(user, context, callback) {
-  const _ = require('lodash@4.17.19')
+  const _ = require('lodash@4.17.19');
 
-  const { IncogniaAPI } = require('@incognia/api@1.0.0')
-  const { Auth0UserUpdateUtilities } = require('@auth0/rule-utilities@0.2.0')
+  const { IncogniaAPI } = require('@incognia/api@1.0.0');
+  const { Auth0UserUpdateUtilities } = require('@auth0/rule-utilities@0.2.0');
 
   const { INCOGNIA_CLIENT_ID, INCOGNIA_CLIENT_SECRET, INCOGNIA_HOME_ADDRESS_PROP } = configuration;
 
@@ -70,7 +70,7 @@ async function incogniaOnboardingRule(user, context, callback) {
       onboardingAssessment = await incogniaAPI.registerOnboardingAssessment({
         installationId: installationId,
         addressLine: homeAddress
-      })
+      });
     } catch (error) {
       console.log('Error calling Incognia API for new signup submission');
       return callback(error);
@@ -104,7 +104,7 @@ async function incogniaOnboardingRule(user, context, callback) {
     first_assessment_at: firstAssessmentAt || Math.round(Date.now() / 1000),
     signup_id: onboardingAssessment.id,
     assessment: onboardingAssessment
-  }
+  };
 
   try {
     userUtils.setAppMeta('incognia', updatedMetadata);

--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -1,0 +1,123 @@
+/**
+ * @title Incognia Onboarding Rule
+ * @overview Verify if the device location behavior matches the address declared during onboarding.
+ * @gallery true
+ * @category marketplace
+ *
+ */
+async function incogniaOnboardingRule(user, context, callback) {
+  const _ = require('lodash')
+
+  const { IncogniaAPI } = require('@incognia/api')
+  const { Auth0UserUpdateUtilities } = require('@auth0/rule-utilities@0.2.0')
+
+  const { INCOGNIA_CLIENT_ID, INCOGNIA_CLIENT_SECRET } = configuration;
+
+  if (!INCOGNIA_CLIENT_ID || !INCOGNIA_CLIENT_SECRET) {
+    console.log('Missing required configuration. Skipping.');
+    return callback(null, user, context);
+  }
+
+  // For this rule to be used, please set 'incognia_onboarding_rule' as 'enabled' in your Auth0
+  // application metadata. This can be done in the advanced settings of your app.
+  const incogniaOnboardingRule = _.get(context, 'clientMetadata.incognia_onboarding_rule');
+  if (!incogniaOnboardingRule || incogniaOnboardingRule !== 'enabled') {
+    console.log('Incognia onboarding rule is not enabled for this client. Skipping');
+    return callback(null, user, context);
+  }
+
+  const installationId = _.get(context, 'request.query.installation_id');
+  if (!installationId) {
+    console.log('Missing installation_id. Skipping.');
+    return callback(null, user, context);
+  }
+
+  // User home address should be set using Auth0's Signup API for example.
+  const homeAddress = _.get(user, 'user_metadata.home_address');
+  if (!homeAddress) {
+    console.log('Missing user home address. Skipping.');
+    return callback(null, user, context);
+  }
+
+  const userUtils = new Auth0UserUpdateUtilities(user, auth0, 'incognia');
+
+  const status = userUtils.getAppMeta('status');
+  // This rule was previously run and calculated the assessment successfully.
+  if (status && status !== 'pending') {
+    console.log('Assessment is already calculated or is unevaluable. Skipping.');
+    return callback(null, user, context);
+  }
+
+  let incogniaAPI;
+  if (global.incogniaAPI) {
+    incogniaAPI = global.incogniaAPI;
+  } else {
+    incogniaAPI = new IncogniaAPI({
+      clientId: INCOGNIA_CLIENT_ID,
+      clientSecret: INCOGNIA_CLIENT_SECRET
+    });
+    global.incogniaAPI = incogniaAPI;
+  }
+
+  let onboardingAssessment;
+  const signupId = userUtils.getAppMeta('signup_id');
+  // The rule was previously run, but Incognia could not assess the signup.
+  if (signupId) {
+    try {
+      onboardingAssessment = await incogniaAPI.getOnboardingAssessment(signupId);
+    } catch (error) {
+      console.log('Error calling Incognia API for signup previously submitted');
+      return callback(error);
+    }
+  // This is the first time the rule is being run with all necessary arguments.
+  } else {
+    try {
+      onboardingAssessment = await incogniaAPI.registerOnboardingAssessment({
+        installationId: installationId,
+        addressLine: homeAddress
+      })
+    } catch (error) {
+      console.log('Error calling Incognia API for new signup submission');
+      return callback(error);
+    }
+  }
+
+  /*
+   * Updates the status in the metadata now that the assessment was calculated. If the new
+   * assessment is valid, the status will go to evaluated and this rule won't be executed again.
+   * If Incognia still doesn't know how to assess the signup, it will try to calculate it again up
+   * to 48 hours after the first try.
+   */
+  const firstAssessmentAt = userUtils.getAppMeta('first_assessment_at');
+  let newStatus;
+  if (onboardingAssessment.riskAssessment !== 'unknown_risk') {
+    newStatus = 'evaluated';
+  } else if (!firstAssessmentAt) {
+    newStatus = 'pending';
+  } else {
+    const firstAssessmentAge = Math.round(Date.now() / 1000) - firstAssessmentAt;
+    // 48 hours limit.
+    if (firstAssessmentAge > 172800) {
+      newStatus = 'unevaluable';
+    } else {
+      newStatus = 'pending';
+    }
+  }
+
+  const updatedMetadata = {
+    status: newStatus,
+    first_assessment_at: firstAssessmentAt || Math.round(Date.now() / 1000),
+    signup_id: onboardingAssessment.id,
+    assessment: onboardingAssessment
+  }
+
+  try {
+    userUtils.setAppMeta('incognia', updatedMetadata);
+    await userUtils.updateAppMeta();
+  } catch (error) {
+    console.log('Error calling Auth0 management API');
+    return callback(error);
+  }
+
+  return callback(null, user, context);
+}

--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -6,9 +6,9 @@
  *
  */
 async function incogniaOnboardingRule(user, context, callback) {
-  const _ = require('lodash')
+  const _ = require('lodash@4.17.19')
 
-  const { IncogniaAPI } = require('@incognia/api')
+  const { IncogniaAPI } = require('@incognia/api@1.0.0')
   const { Auth0UserUpdateUtilities } = require('@auth0/rule-utilities@0.2.0')
 
   const { INCOGNIA_CLIENT_ID, INCOGNIA_CLIENT_SECRET } = configuration;


### PR DESCRIPTION
### Description

The purpose of this PR is to have the first rule template available for the Marketplace integration (Incognia). As a prerequisite, users have to declare their home addresses during account creation. What Incognia does is to compare the location history of the device with the declared address to assess the risk of synthetic identity fraud.

This also uses the Incognia API Node Wrapper (https://www.npmjs.com/package/@incognia/api), which is not yet fully deployed to Auth0 environment. Because of this, we did not test the rule yet.

![image](https://user-images.githubusercontent.com/5231647/111472466-bde01700-8708-11eb-8ff1-9e878edf3c50.png)

### Testing

- [ ] Test the rule code by creating it at our Auth0 tenant.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
