### PR TITLE
Switching from user_meradata to app_metadata

### DIFF
--- a/src/rules/cumulio-add-metadata-to-tokens.js
+++ b/src/rules/cumulio-add-metadata-to-tokens.js
@@ -1,18 +1,18 @@
 /**
- * @title User metadata for Cumul.io
- * @overview Add Cumul.io user metadata to tokens to be used for Cumul.io dashboard filtering
+ * @title User app_metadata for Cumul.io
+ * @overview Add Cumul.io user app_metadata to tokens to be used for Cumul.io dashboard filtering
  * @gallery true
  * @category marketplace
  *
  * This integration simplifies the process of making full use of integrated Cumul.io dashboards' multi tenant features
  * by using Auth0 as its authentication layer. The integration will allow you to set up and use user
- * information in Auth0 to filter and structure your Cumul.io dashboards.
+ * information in Auth0 as Cumul.io parameters to filter and structure your Cumul.io dashboards.
  */
 
 function addMetadataToTokens(user, context, callback) {
   const namespace = 'https://cumulio/';
-  user.user_metadata = user.user_metadata || {};
-  const cumulioMetadata = user.user_metadata.cumulio || {};
+  user.app_metadata = user.app_metadata || {};
+  const cumulioMetadata = user.app_metadata.cumulio || {};
   if (typeof cumulioMetadata === 'object' && cumulioMetadata !== null) {
     Object.keys(cumulioMetadata).forEach((k) => {
       context.idToken[namespace + k] = cumulioMetadata[k];
@@ -20,7 +20,7 @@ function addMetadataToTokens(user, context, callback) {
     });
   } else {
     console.log(
-      'Make sure that user_metadata.cumulio is an object with keys and values'
+      'Make sure that app_metadata.cumulio is an object with keys and values'
     );
     return;
   }


### PR DESCRIPTION
Submitting this updated rule to default to requesting customers to use app_metadata instead of user_metadata to avoid any issues regarding user permissions.