### PR TITLE
[DXEC-763] Remove Rule templates that have been migrated to Actions

### DIFF
--- a/src/rules/arengu-policy-acceptance.js
+++ b/src/rules/arengu-policy-acceptance.js
@@ -1,7 +1,7 @@
 /**
  * @title Arengu Policy Acceptance
  * @overview Require your users to accept custom privacy policies or new terms.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [Aregnu Policy Acceptance integration](https://marketplace.auth0.com/integrations/arengu-policy-acceptance) for more information and detailed installation instructions.

--- a/src/rules/arengu-progressive-profiling.js
+++ b/src/rules/arengu-progressive-profiling.js
@@ -1,7 +1,7 @@
 /**
  * @title Arengu Progressive Profiling
  * @overview Capture new users' information in your authentication flows.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [Aregnu Progressive Profiling integration](https://marketplace.auth0.com/integrations/arengu-progressive-profiling) for more information and detailed installation instructions.

--- a/src/rules/cumulio-add-metadata-to-tokens.js
+++ b/src/rules/cumulio-add-metadata-to-tokens.js
@@ -1,7 +1,7 @@
 /**
  * @title User app_metadata for Cumul.io
  * @overview Add Cumul.io user app_metadata to tokens to be used for Cumul.io dashboard filtering
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * This integration simplifies the process of making full use of integrated Cumul.io dashboards' multi tenant features

--- a/src/rules/eva-voice-biometric.js
+++ b/src/rules/eva-voice-biometric.js
@@ -1,8 +1,8 @@
 /**
- *	@title EVA Voice Biometric connector
- *	@overview EVA Voice Biometric connector rule for Auth0 enables voice enrolment and verification as a second factor
- *	@gallery true
- *	@category marketplace
+ * @title EVA Voice Biometric connector
+ * @overview EVA Voice Biometric connector rule for Auth0 enables voice enrolment and verification as a second factor
+ * @gallery false
+ * @category marketplace
  *
  * Please see the [EVA Voice Biometrics integration](https://marketplace.auth0.com/integrations/eva-voice-biometrics) for more information and detailed installation instructions.
  *

--- a/src/rules/iddataweb-verification-workflow.js
+++ b/src/rules/iddataweb-verification-workflow.js
@@ -1,7 +1,7 @@
 /**
  * @title ID DataWeb Verification Workflow
  * @overview Verify your user's identity in 180+ countries with ID DataWeb's adaptive Verification Workflows.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [ID DataWeb integration](https://marketplace.auth0.com/integrations/iddataweb-identity-verification) for more information and detailed installation instructions.

--- a/src/rules/incognia-authentication.js
+++ b/src/rules/incognia-authentication.js
@@ -1,7 +1,7 @@
 /**
  * @title Incognia Authentication Rule
  * @overview Verify if the device logging in is at a trusted location.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [Incognia Authentication integration](https://marketplace.auth0.com/integrations/incognia-authentication) for more information and detailed installation instructions.

--- a/src/rules/incognia-onboarding.js
+++ b/src/rules/incognia-onboarding.js
@@ -1,7 +1,7 @@
 /**
  * @title Incognia Onboarding Rule
  * @overview Verify if the device location behavior matches the address declared during onboarding.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [Incognia Onboarding integration](https://marketplace.auth0.com/integrations/incognia-onboarding) for more information and detailed installation instructions.

--- a/src/rules/mylife-digital-progressive-consent.js
+++ b/src/rules/mylife-digital-progressive-consent.js
@@ -1,7 +1,7 @@
 /**
 * @title Consentric Progressive Consent
 * @overview Uses a widget to capture missing consents and preferences at login to boost engagement and support compliance
-* @gallery true
+* @gallery false
 * @category marketplace
 *
 * Please see the [MyLife Digital integration](https://marketplace.auth0.com/integrations/mylife-digital-progressive-consent) for more information and detailed installation instructions.

--- a/src/rules/onetrust-consent-management.js
+++ b/src/rules/onetrust-consent-management.js
@@ -1,7 +1,7 @@
 /**
  * @title OneTrust Consent Management
  * @overview Enhance Auth0 user profiles with consent, opt-ins and communication preferences data.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [OneTrust integration](https://marketplace.auth0.com/integrations/onetrust-consent-management) for more information and detailed installation instructions.

--- a/src/rules/scaled-access-relationships-claim.js
+++ b/src/rules/scaled-access-relationships-claim.js
@@ -1,7 +1,7 @@
 /**
  * @title Scaled Access relationship-based claims
  * @overview Adds a claim based on the relationships the subject has in Scaled Access
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * Please see the [Scaled Access integration](https://marketplace.auth0.com/integrations/scaled-access) for more information and detailed installation instructions.

--- a/src/rules/seczetta-get-risk-score.js
+++ b/src/rules/seczetta-get-risk-score.js
@@ -1,7 +1,7 @@
 /**
  * @title SecZetta Get Risk Score
  * @overview Grab the risk score from SecZetta to use in the authentication flow
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * **Required configuration** (this Rule will be skipped if any of the below are not defined):

--- a/src/rules/yoonik-face.js
+++ b/src/rules/yoonik-face.js
@@ -1,7 +1,7 @@
 /**
  * @title YooniK Face Authentication
  * @overview Redirect to your YooniK Face Application for Face Authentication during login.
- * @gallery true
+ * @gallery false
  * @category marketplace
  *
  * **Required configuration** (this Rule will be skipped if any of the below are not defined):


### PR DESCRIPTION
Marks all Rules that have been migrated to Actions as "unpublished" so they do not appear in the dashboard. Three Rules remain on Marketplace so those have not been changed:

https://marketplace.auth0.com/features/rules